### PR TITLE
[Fix#646]429 발생하지 않더라도 기본 1~5초 텀 두도록 설정

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/core/Scrapper.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/Scrapper.kt
@@ -142,6 +142,7 @@ class Scrapper(
 
         while (attempt < maxRetries) {
             try {
+                TimeUnit.SECONDS.sleep((1..5).random().toLong())
                 return connectionFactory
                     .createConnection(url)
                     .execute()


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #646 

💁‍♂️ PR 내용
----
- 429 에러 발생하지 않더라도 기본적으로 sleep 하도록 설정(1~5초 중 랜덤)

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 각 연결 요청 시도 전에 1~5초의 무작위 지연이 추가되어, 네트워크 요청의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->