### PR TITLE
[Fix/#648] GPT 호출시 raw text가 압축되어 보내지던 문제 해결

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/config/jpa/CompressedBase64Converter.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/config/jpa/CompressedBase64Converter.kt
@@ -1,0 +1,12 @@
+package com.few.generator.config.jpa
+
+import com.few.generator.support.utils.CompressUtils
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+class CompressedBase64Converter : AttributeConverter<String, String> {
+    override fun convertToDatabaseColumn(attribute: String?): String? = attribute?.let { CompressUtils.compress(it) }
+
+    override fun convertToEntityAttribute(dbData: String?): String? = dbData?.let { CompressUtils.decompress(it) }
+}

--- a/domain/generator/src/main/kotlin/com/few/generator/domain/RawContents.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/domain/RawContents.kt
@@ -1,5 +1,6 @@
 package com.few.generator.domain
 
+import com.few.generator.config.jpa.CompressedBase64Converter
 import jakarta.persistence.*
 
 @Entity
@@ -17,6 +18,7 @@ data class RawContents(
     @Column(nullable = true)
     val thumbnailImageUrl: String? = null,
     @Column(nullable = true, columnDefinition = "TEXT")
+    @Convert(converter = CompressedBase64Converter::class)
     val rawTexts: String,
     @Column(nullable = true, columnDefinition = "TEXT")
     val imageUrls: String = "[]",

--- a/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
@@ -5,7 +5,6 @@ import com.few.generator.core.Scrapper
 import com.few.generator.domain.Category
 import com.few.generator.domain.RawContents
 import com.few.generator.repository.RawContentsRepository
-import com.few.generator.support.utils.CompressUtils
 import com.google.gson.Gson
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.annotation.Qualifier
@@ -57,7 +56,7 @@ class RawContentsService(
                 title = scrappedResult.title,
                 description = scrappedResult.description,
                 thumbnailImageUrl = scrappedResult.thumbnailImageUrl,
-                rawTexts = CompressUtils.compress(scrappedResult.rawTexts.joinToString("\n")),
+                rawTexts = scrappedResult.rawTexts.joinToString("\n"),
                 imageUrls = gson.toJson(scrappedResult.images) ?: "[]",
                 category = category.code,
             ),

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/RawContentsBrowseContentUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/RawContentsBrowseContentUseCase.kt
@@ -6,7 +6,6 @@ import com.few.generator.repository.GenRepository
 import com.few.generator.repository.ProvisioningContentsRepository
 import com.few.generator.repository.RawContentsRepository
 import com.few.generator.support.jpa.GeneratorTransactional
-import com.few.generator.support.utils.CompressUtils
 import com.few.generator.usecase.out.*
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -42,7 +41,7 @@ class RawContentsBrowseContentUseCase(
                     title = rawContents.title,
                     description = rawContents.description,
                     thumbnailImageUrl = rawContents.thumbnailImageUrl,
-                    rawTexts = CompressUtils.decompress(rawContents.rawTexts),
+                    rawTexts = rawContents.rawTexts,
                     imageUrls = gson.fromJson(rawContents.imageUrls, object : TypeToken<List<String>>() {}.type),
                     createdAt = rawContents.createdAt!!,
                 ),


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #648 

💁‍♂️ PR 내용
----
- 압축/압축해제를 JPA Converter로 적용해서 JPA단에서 해결될 수 있도록 변경

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 데이터 저장 시 텍스트가 자동으로 압축 및 Base64 인코딩되어 데이터베이스에 저장되고, 불러올 때 자동으로 복원됩니다.

- **버그 수정**
  - 텍스트 데이터의 압축 및 복원을 수동으로 처리할 필요 없이 자동으로 처리되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->