### PR TITLE
[Fix/#645] GPT응답 타임아웃 해결시도 - Feign Client 호출(GPT)시 Retryer 설정

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorFeignConfig.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorFeignConfig.kt
@@ -4,6 +4,7 @@ import feign.Retryer
 import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import java.util.concurrent.TimeUnit
 
 @Configuration
@@ -14,10 +15,11 @@ import java.util.concurrent.TimeUnit
 )
 class GeneratorFeignConfig {
     @Bean
-    fun feignRetryer(): Retryer =
+    @Primary
+    fun retryer(): Retryer =
         Retryer.Default(
             TimeUnit.SECONDS.toMillis(1),
-            TimeUnit.SECONDS.toMillis(1),
-            1,
+            TimeUnit.SECONDS.toMillis(2),
+            2,
         )
 }

--- a/domain/generator/src/main/resources/application-generator-local.yaml
+++ b/domain/generator/src/main/resources/application-generator-local.yaml
@@ -7,7 +7,6 @@ spring:
                         connectTimeout: 10000
                         readTimeout: 60000
                         loggerLevel: full
-                    retryer: com.few.generator.config.GeneratorFeignConfig
                     openai:
                         url: https://api.openai.com
                         errorDecoder: com.few.generator.config.feign.OpenAiErrorDecoder

--- a/domain/generator/src/main/resources/application-generator-prd.yaml
+++ b/domain/generator/src/main/resources/application-generator-prd.yaml
@@ -7,7 +7,6 @@ spring:
                         connectTimeout: 10000
                         readTimeout: 60000
                         loggerLevel: full
-                    retryer: com.few.generator.config.GeneratorFeignConfig
                     openai:
                         url: https://api.openai.com
                         errorDecoder: com.few.generator.config.feign.OpenAiErrorDecoder


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #645 

💁‍♂️ PR 내용
----
- 재시도 텀은 1초부터 시작해서 최대 2초까지 증가함
- 총 재시도 2회

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----
![image](https://github.com/user-attachments/assets/c9df18f3-af95-4e34-823e-e8c325179997)
- 로컬 테스트 : 실패 발생 후 재시도 로그 확인


🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Feign 클라이언트의 재시도 동작이 기본적으로 2회까지, 최대 2초까지 재시도하도록 설정되었습니다.

- **버그 수정**
  - Feign 클라이언트의 연결 타임아웃이 60초에서 10초로 단축되어 응답 지연 시 빠르게 실패하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->