### PR TITLE
[Feat/#643] 컨텐츠 스케줄링 동시 1회만 수행되도록 수정

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
@@ -15,6 +15,7 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import web.handler.exception.BadRequestException
 import java.time.LocalDateTime
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.measureTimeMillis
 
 @Component
@@ -25,10 +26,23 @@ class SchedulingUseCase(
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     private val log = KotlinLogging.logger {}
+    private val isRunning = AtomicBoolean(false)
 
     @Scheduled(cron = "\${scheduling.cron.generator}")
     @GeneratorTransactional
     fun execute() {
+        if (!isRunning.compareAndSet(false, true)) {
+            throw BadRequestException("Contents scheduling is already running. Please try again later.")
+        }
+
+        try {
+            doExecute()
+        } finally {
+            isRunning.set(false)
+        }
+    }
+
+    fun doExecute() {
         val startTime = LocalDateTime.now()
         var rawContents = emptyMap<Category, List<RawContents>>()
         var provisionings = emptyMap<Category, List<ProvisioningContents>>()

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
@@ -42,7 +42,7 @@ class SchedulingUseCase(
         }
     }
 
-    fun doExecute() {
+    private fun doExecute() {
         val startTime = LocalDateTime.now()
         var rawContents = emptyMap<Category, List<RawContents>>()
         var provisionings = emptyMap<Category, List<ProvisioningContents>>()


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #643 

💁‍♂️ PR 내용
----
- 컨텐츠 스케줄링은 무거운 작업이므로 동시 1회만 수행되도록 반영
- 단, replica가 될 경우 해당 변경로직 대체 필요(redis / DB 활용 등)

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----
<img width="731" alt="image" src="https://github.com/user-attachments/assets/334bab24-67fd-46ee-bf9d-24cd1552af0e" />

- 이미 컨텐츠 스케줄링이 수행중인 경우 재호출시 에러 응답

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 스케줄링 실행 시 동시에 여러 번 실행되는 문제를 방지하여, 이미 실행 중일 때는 오류 메시지를 표시하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->