### PR TITLE
[Fix/#657] 카테고리 별 정해진 개수만 크롤링 수행되도록 수정

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/core/Scrapper.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/Scrapper.kt
@@ -130,12 +130,13 @@ class Scrapper(
             .map {
                 log.debug { "Extracted URL: $it" }
                 it
-            }.mapNotNull {
-                getWithRetry(it)
-                    .select("a")
-                    .firstOrNull { it.text() == "기사원문" }
-                    ?.attr("href")
             }.toSet()
+
+    fun extractOriginUrl(url: String): String? =
+        getWithRetry(url)
+            .select("a")
+            .firstOrNull { it.text() == "기사원문" }
+            ?.attr("href")
 
     private fun getWithRetry(url: String): Document {
         var attempt = 0
@@ -156,6 +157,7 @@ class Scrapper(
                         attempt++
                         continue
                     }
+
                     else -> throw e
                 }
             }

--- a/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
@@ -27,29 +27,31 @@ class RawContentsService(
         val result = mutableMapOf<Category, List<RawContents>>()
 
         for (category in Category.entries) {
-            if (category.rootUrl != null) {
-                val urls = scrapper.extractUrlsByCategory(category.rootUrl)
-                val rawContents = mutableListOf<RawContents>()
+            if (category.rootUrl == null) {
+                continue
+            }
 
-                for (url in urls) {
-                    val originUrl = scrapper.extractOriginUrl(url)
-                    if (originUrl == null || rawContentsRepository.findByUrl(originUrl) != null) {
-                        continue
-                    }
+            val urls = scrapper.extractUrlsByCategory(category.rootUrl)
+            val rawContents = mutableListOf<RawContents>()
 
-                    val content = create(originUrl, category)
-                    if (content == null) {
-                        continue
-                    }
-
-                    rawContents.add(content)
-                    if (rawContents.size >= contentsCountByCategory) {
-                        break
-                    }
+            for (url in urls) {
+                val originUrl = scrapper.extractOriginUrl(url)
+                if (originUrl == null || rawContentsRepository.findByUrl(originUrl) != null) {
+                    continue
                 }
 
-                result[category] = rawContents
+                val rawContent = create(originUrl, category)
+                if (rawContent == null) {
+                    continue
+                }
+
+                rawContents.add(rawContent)
+                if (rawContents.size >= contentsCountByCategory) {
+                    break
+                }
             }
+
+            result[category] = rawContents
         }
 
         return result


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #657 

💁‍♂️ PR 내용
----
- AS-IS: 스크래핑한 모든 URL에 대해서 크롤링 수행 후 take로 일정 개수를 취함
- TO-BE: 지정한 일정 개수만큼만 크롤링 수행
-> 컨텐츠 스케줄링 수행시간이 대폭 줄어들 것으로 기대

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
