### PR TITLE
[Fix/#659] 컨텐츠 생성 절차 URL 별로 분리

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/core/Scrapper.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/Scrapper.kt
@@ -1,6 +1,7 @@
 package com.few.generator.core
 
 import com.few.generator.config.JsoupConnectionFactory
+import com.few.generator.domain.Category
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jsoup.HttpStatusException
 import org.jsoup.nodes.Document
@@ -29,6 +30,13 @@ class Scrapper(
 ) {
     private val log = KotlinLogging.logger {}
     private val imageExtensions = listOf(".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg")
+
+    fun extractUrlsByCategories(): Map<Category, Set<String>> =
+        Category.entries
+            .filter { it.rootUrl != null }
+            .associateWith { category ->
+                extractUrlsByCategory(category.rootUrl!!)
+            }
 
     fun isValidSentence(sentence: String): Boolean {
         val text = sentence.trim()

--- a/domain/generator/src/main/kotlin/com/few/generator/event/dto/ContentsSchedulingEventDto.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/dto/ContentsSchedulingEventDto.kt
@@ -5,9 +5,7 @@ import java.time.LocalDateTime
 data class ContentsSchedulingEventDto(
     val isSuccess: Boolean,
     val startTime: LocalDateTime,
-    val timeOfCreatingRawContents: String,
-    val timeOfCreatingProvisionings: String,
-    val timeOfCreatingGens: String,
     val totalTime: String,
-    val countByCategory: String,
+    val message: String,
+    val result: String,
 )

--- a/domain/generator/src/main/kotlin/com/few/generator/event/handler/ContentsSchedulingHandler.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/handler/ContentsSchedulingHandler.kt
@@ -32,24 +32,16 @@ class ContentsSchedulingHandler(
                             description = event.startTime.toString(),
                         ),
                         Embed(
-                            title = "1️⃣ RawContents 생성 시간",
-                            description = event.timeOfCreatingRawContents,
-                        ),
-                        Embed(
-                            title = "2️⃣ ProvisioningContents 생성 시간",
-                            description = event.timeOfCreatingProvisionings,
-                        ),
-                        Embed(
-                            title = "3️⃣ Gens 생성 시간",
-                            description = event.timeOfCreatingGens,
-                        ),
-                        Embed(
                             title = "⌛ 전체 소요 시간",
                             description = event.totalTime,
                         ),
                         Embed(
-                            title = ">> 카테고리 별 생성 컨텐츠 개수 <<",
-                            description = event.countByCategory,
+                            title = ">> message <<",
+                            description = event.message,
+                        ),
+                        Embed(
+                            title = ">> result <<",
+                            description = event.result,
                         ),
                     ),
             )

--- a/domain/generator/src/main/kotlin/com/few/generator/service/GenService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/GenService.kt
@@ -20,8 +20,8 @@ class GenService(
     private val log = KotlinLogging.logger {}
 
     fun create(
-        rawContents: RawContents,
-        provisioningContents: ProvisioningContents,
+        rawContent: RawContents,
+        provisioningContent: ProvisioningContents,
         typeCodes: Set<Int>,
     ): List<Gen> {
         log.info { "Trying to Generate ${typeCodes.size} Gen Types..." }
@@ -39,12 +39,12 @@ class GenService(
                 genGenerationStrategies[genType.title]!!.generate(
                     Material(
                         // from rawContents
-                        title = rawContents.title,
-                        description = rawContents.description,
+                        title = rawContent.title,
+                        description = rawContent.description,
                         // from provisioningContents
-                        coreTextsJson = provisioningContents.coreTextsJson,
-                        provisioningContentsId = provisioningContents.id!!,
-                        category = Category.from(provisioningContents.category),
+                        coreTextsJson = provisioningContent.coreTextsJson,
+                        provisioningContentsId = provisioningContent.id!!,
+                        category = Category.from(provisioningContent.category),
                     ),
                 )
             }
@@ -53,6 +53,27 @@ class GenService(
          * bulk insert
          */
         return genRepository.saveAll(generatedResults)
+    }
+
+    fun create(
+        rawContent: RawContents,
+        provisioningContent: ProvisioningContents,
+    ): Gen {
+        log.info { "Craete GEN with default gen type(STRATEGY_NAME_SHORT)..." }
+
+        return genRepository.save(
+            genGenerationStrategies[GenType.STRATEGY_NAME_SHORT.title]!!.generate(
+                Material(
+                    // from rawContents
+                    title = rawContent.title,
+                    description = rawContent.description,
+                    // from provisioningContents
+                    coreTextsJson = provisioningContent.coreTextsJson,
+                    provisioningContentsId = provisioningContent.id!!,
+                    category = Category.from(provisioningContent.category),
+                ),
+            ),
+        )
     }
 
     fun getByProvisioningContentsId(provisioningContentsId: Long): Set<Gen> =

--- a/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
@@ -23,40 +23,6 @@ class RawContentsService(
 ) {
     private val log = KotlinLogging.logger {}
 
-    fun create(): Map<Category, List<RawContents>> {
-        val result = mutableMapOf<Category, List<RawContents>>()
-
-        for (category in Category.entries) {
-            if (category.rootUrl == null) {
-                continue
-            }
-
-            val urls = scrapper.extractUrlsByCategory(category.rootUrl)
-            val rawContents = mutableListOf<RawContents>()
-
-            for (url in urls) {
-                val originUrl = scrapper.extractOriginUrl(url)
-                if (originUrl == null || rawContentsRepository.findByUrl(originUrl) != null) {
-                    continue
-                }
-
-                val rawContent = create(originUrl, category)
-                if (rawContent == null) {
-                    continue
-                }
-
-                rawContents.add(rawContent)
-                if (rawContents.size >= contentsCountByCategory) {
-                    break
-                }
-            }
-
-            result[category] = rawContents
-        }
-
-        return result
-    }
-
     fun create(
         sourceUrl: String,
         category: Category,

--- a/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
@@ -26,17 +26,14 @@ class RawContentsService(
     fun create(
         sourceUrl: String,
         category: Category,
-    ): RawContents? {
+    ): RawContents {
         rawContentsRepository.findByUrl(sourceUrl)?.let {
             throw BadRequestException("이미 생성된 컨텐츠가 있습니다. ID: ${it.id}, URL: $sourceUrl")
         }
 
         val scrappedResult =
             scrapper.scrape(sourceUrl)
-                ?: run {
-                    log.warn { "Failed to scrape content. Skipped this contents. URL: $sourceUrl" }
-                    return null
-                }
+                ?: throw BadRequestException("URL에서 컨텐츠를 스크랩할 수 없습니다. URL: $sourceUrl")
 
         return rawContentsRepository.save(
             RawContents(

--- a/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
@@ -89,4 +89,6 @@ class RawContentsService(
         rawContentsRepository
             .findById(id)
             .orElseThrow { BadRequestException("Raw 컨텐츠가 존재하지 않습니다.") }
+
+    fun exists(url: String): Boolean = rawContentsRepository.findByUrl(url) != null
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
@@ -1,15 +1,14 @@
 package com.few.generator.usecase
 
-import com.few.generator.domain.Category
+import com.few.generator.core.Scrapper
 import com.few.generator.domain.GenType
-import com.few.generator.domain.ProvisioningContents
-import com.few.generator.domain.RawContents
 import com.few.generator.event.dto.ContentsSchedulingEventDto
 import com.few.generator.service.GenService
 import com.few.generator.service.ProvisioningService
 import com.few.generator.service.RawContentsService
 import com.few.generator.support.jpa.GeneratorTransactional
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -24,6 +23,9 @@ class SchedulingUseCase(
     private val provisioningService: ProvisioningService,
     private val genService: GenService,
     private val applicationEventPublisher: ApplicationEventPublisher,
+    private val scrapper: Scrapper,
+    @Value("\${generator.contents.countByCategory}")
+    private val contentsCountByCategory: Int,
 ) {
     private val log = KotlinLogging.logger {}
     private val isRunning = AtomicBoolean(false)
@@ -44,50 +46,28 @@ class SchedulingUseCase(
 
     private fun doExecute() {
         val startTime = LocalDateTime.now()
-        var rawContents = emptyMap<Category, List<RawContents>>()
-        var provisionings = emptyMap<Category, List<ProvisioningContents>>()
-
-        var timeOfCreatingRawContents = 0.0
-        var timeOfCreatingProvisionings = 0.0
-        var timeOfCreatingGens = 0.0
         var isSuccess = true
+        var creationTimeSec = 0.0
+        var exception: Throwable? = null
+        var result: Pair<Int, Int> = Pair(0, 0)
 
         runCatching {
-            measureAndReturn { rawContentsService.create() }
-                .also { (result, time) ->
-                    rawContents = result
-                    timeOfCreatingRawContents = time
-                }
-
-            measureAndReturn { createProvisionings(rawContents) }
-                .also { (result, time) ->
-                    provisionings = result
-                    timeOfCreatingProvisionings = time
-                }
-
-            measureTimeMillis {
-                createGens(rawContents, provisionings)
-            }.msToSeconds().also { timeOfCreatingGens = it }
-        }.onFailure {
+            creationTimeSec =
+                measureTimeMillis {
+                    result = create()
+                }.msToSeconds()
+        }.onFailure { ex ->
             isSuccess = false
-            log.error(it) { "콘텐츠 스케줄링 중 오류 발생" }
+            log.error(ex) { "콘텐츠 스케줄링 중 오류 발생" }
+            exception = ex
         }.also {
-            val totalTime = timeOfCreatingRawContents + timeOfCreatingProvisionings + timeOfCreatingGens
-            val countByCategory =
-                rawContents.entries.joinToString(separator = "\n") { (category, rawList) ->
-                    val count = rawList.count { it != null }
-                    "[${category.title}] $count"
-                }
-
             log.info {
                 buildString {
-                    appendLine("# isSuccess: $isSuccess")
-                    appendLine("# 시작 시간: $startTime")
-                    appendLine("# 카테고리 별 생성 개수: $countByCategory")
-                    appendLine("✅ [1단계] RawContents: $timeOfCreatingRawContents s")
-                    appendLine("✅ [2단계] Provisionings: $timeOfCreatingProvisionings s")
-                    appendLine("✅ [3단계] Gens: $timeOfCreatingGens s")
-                    append("-> 전체 : $totalTime s")
+                    appendLine("✅ isSuccess: $isSuccess")
+                    appendLine("✅ 시작 시간: $startTime")
+                    appendLine("✅ 소요 시간: $creationTimeSec")
+                    appendLine("✅ ${exception?.cause?.message}")
+                    append("✅ 생성(${result.first}) / 스킵(${result.second})")
                 }
             }
 
@@ -95,47 +75,55 @@ class SchedulingUseCase(
                 ContentsSchedulingEventDto(
                     isSuccess = isSuccess,
                     startTime = startTime,
-                    timeOfCreatingRawContents = "%.3f".format(timeOfCreatingRawContents),
-                    timeOfCreatingProvisionings = "%.3f".format(timeOfCreatingProvisionings),
-                    timeOfCreatingGens = "%.3f".format(timeOfCreatingGens),
-                    totalTime = "%.3f".format(totalTime),
-                    countByCategory = countByCategory,
+                    totalTime = "%.3f".format(creationTimeSec),
+                    message = if (isSuccess) "None" else exception?.cause?.message ?: "Unknown error",
+                    result = if (isSuccess) "생성(${result.first}) / 스킵(${result.second})" else "None",
                 ),
             )
 
             if (!isSuccess) {
-                throw BadRequestException("콘텐츠 스케줄링에 실패 : $startTime")
+                throw BadRequestException("콘텐츠 스케줄링에 실패 : ${exception?.cause?.message}")
             }
         }
     }
 
-    private fun createProvisionings(rawContents: Map<Category, List<RawContents>>): Map<Category, List<ProvisioningContents>> =
-        rawContents.mapValues { (_, rawContents) ->
-            rawContents.map { rawContent ->
-                provisioningService.create(rawContent)
+    private fun create(): Pair<Int, Int> {
+        val urlsByCategories = scrapper.extractUrlsByCategories()
+
+        var successCnt = 0
+        var failCnt = 0
+
+        urlsByCategories.forEach { (category, urls) ->
+            val urls = urls ?: return@forEach
+            var successCntByCategory = 0
+
+            for (url in urls) {
+                val originUrl =
+                    scrapper
+                        .extractOriginUrl(url)
+                        ?.takeUnless { rawContentsService.exists(it) } ?: continue
+
+                try {
+                    val rawContent = rawContentsService.create(originUrl, category) ?: continue
+                    val provisioningContent = provisioningService.create(rawContent)
+
+                    val genTypes = GenType.entries.map { it.code }.toSet()
+                    genService.create(rawContent, provisioningContent, genTypes)
+
+                    successCntByCategory++
+                    successCnt++
+
+                    if (successCntByCategory >= contentsCountByCategory) break
+                } catch (e: Exception) {
+                    failCnt++
+                    log.error(e) {
+                        "콘텐츠 생성 중 오류 발생하여 Skip 처리. URL: $url, 카테고리: ${category.title}"
+                    }
+                }
             }
         }
 
-    private fun createGens(
-        rawContents: Map<Category, List<RawContents>>,
-        provisionings: Map<Category, List<ProvisioningContents>>,
-    ) {
-        val genTypes: Set<Int> = GenType.entries.map { it.code }.toSet()
-
-        rawContents.forEach { (category, rawContentsList) ->
-            val provisioningList = provisionings[category].orEmpty()
-
-            rawContentsList.zip(provisioningList).forEach { (raw, provisioning) ->
-                genService.create(raw, provisioning, genTypes)
-            }
-        }
-    }
-
-    private inline fun <T> measureAndReturn(block: () -> T): Pair<T, Double> {
-        val start = System.currentTimeMillis()
-        val result = block()
-        val elapsed = System.currentTimeMillis() - start
-        return result to elapsed.msToSeconds()
+        return successCnt to failCnt
     }
 
     private fun Long.msToSeconds(): Double = this / 1000.0

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
@@ -97,13 +97,13 @@ class SchedulingUseCase(
             var successCntByCategory = 0
 
             for (url in urls) {
-                val originUrl =
-                    scrapper
-                        .extractOriginUrl(url)
-                        ?.takeUnless { rawContentsService.exists(it) } ?: continue
-
                 try {
-                    val rawContent = rawContentsService.create(originUrl, category) ?: continue
+                    val originUrl =
+                        scrapper
+                            .extractOriginUrl(url)
+                            ?.takeUnless { rawContentsService.exists(it) } ?: throw RuntimeException("이미 생성된 URL입니다: $url")
+
+                    val rawContent = rawContentsService.create(originUrl, category)
                     val provisioningContent = provisioningService.create(rawContent)
                     genService.create(rawContent, provisioningContent)
 

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
@@ -1,7 +1,6 @@
 package com.few.generator.usecase
 
 import com.few.generator.core.Scrapper
-import com.few.generator.domain.GenType
 import com.few.generator.event.dto.ContentsSchedulingEventDto
 import com.few.generator.service.GenService
 import com.few.generator.service.ProvisioningService
@@ -106,9 +105,7 @@ class SchedulingUseCase(
                 try {
                     val rawContent = rawContentsService.create(originUrl, category) ?: continue
                     val provisioningContent = provisioningService.create(rawContent)
-
-                    val genTypes = GenType.entries.map { it.code }.toSet()
-                    genService.create(rawContent, provisioningContent, genTypes)
+                    genService.create(rawContent, provisioningContent)
 
                     successCntByCategory++
                     successCnt++

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
@@ -65,8 +65,8 @@ class SchedulingUseCase(
                     appendLine("✅ isSuccess: $isSuccess")
                     appendLine("✅ 시작 시간: $startTime")
                     appendLine("✅ 소요 시간: $creationTimeSec")
-                    appendLine("✅ ${exception?.cause?.message}")
-                    append("✅ 생성(${result.first}) / 스킵(${result.second})")
+                    appendLine("✅ message: ${exception?.cause?.message}")
+                    append("✅ result: 생성(${result.first}) / 스킵(${result.second})")
                 }
             }
 


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #659 

💁‍♂️ PR 내용
----
- AS-IS: 'raw contents 만들고 -> provisioning 만들고 -> gen 만들고' 절차를 1회만 진행. 그리고 그 과정 중 실패하면 전체 실패
- TO-BE: 'raw contents 만들고 -> provisioning 만들고 -> gen 만들고' 절차를 URL 별로 진행해야 함. 그리고 그 URL에 대해서 실패했다면, 전체 실패가 아니라, 그 URL에 대해서 skip 하고 다음 URL에 대해서 진행해야 함.
- 이유: URL을 잘 추출했더라도 GPT 호출, GEN, Provisioning, Raw contents 생성 과정에서 에러 발생할 수 있기 때문. 따라서 생성 도중에 에러가 발생한 URL에 대해선 skip 

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 카테고리별로 URL을 추출하는 기능이 추가되었습니다.
	- 단일 원본 콘텐츠 및 프로비저닝 콘텐츠로부터 생성된 결과물을 만드는 기능이 추가되었습니다.
	- 중복 URL 확인 기능이 추가되었습니다.

- **기능 개선**
	- 콘텐츠 스케줄링 과정이 단일 흐름으로 간소화되어 전체 처리 시간이 단일 값으로 제공됩니다.
	- 성공/실패 건수 및 메시지, 결과 요약 정보가 이벤트 및 알림에 포함됩니다.

- **기존 기능 변경 및 제거**
	- 상세 단계별 처리 시간 및 카테고리별 건수 정보가 더 이상 제공되지 않습니다.
	- 복수 URL/카테고리 기반 원본 콘텐츠 일괄 생성 기능이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->