### PR TITLE
[Feat/#669] 컨텐츠 조회 무한스크롤 조회 구현

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
@@ -82,7 +82,9 @@ class ContentsGeneratorController(
         )
     }
 
-    @GetMapping
+    @GetMapping(
+        value = ["/contents"],
+    )
     fun readContents(
         @RequestParam(
             required = false,

--- a/domain/generator/src/main/kotlin/com/few/generator/controller/response/BrowseContentResponses.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/response/BrowseContentResponses.kt
@@ -9,7 +9,7 @@ data class BrowseContentResponses(
 )
 
 data class BrowseContentResponse(
-    val id: Int,
+    val id: Long,
     val url: String,
     val thumbnailImageUrl: String?,
     val mediaType: CodeValueResponse,

--- a/domain/generator/src/main/kotlin/com/few/generator/controller/response/BrowseContentResponses.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/response/BrowseContentResponses.kt
@@ -1,0 +1,22 @@
+package com.few.generator.controller.response
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDateTime
+
+data class BrowseContentResponses(
+    val contents: List<BrowseContentResponse>,
+    val isLast: Boolean,
+)
+
+data class BrowseContentResponse(
+    val id: Int,
+    val url: String,
+    val thumbnailImageUrl: String?,
+    val mediaType: CodeValueResponse,
+    val headline: String,
+    val summary: String,
+    val highlightTexts: List<String>,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    val createdAt: LocalDateTime,
+    val category: CodeValueResponse,
+)

--- a/domain/generator/src/main/kotlin/com/few/generator/domain/Gen.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/domain/Gen.kt
@@ -6,7 +6,10 @@ import jakarta.persistence.*
 @Entity
 @Table(
     name = "gen",
-    indexes = [Index(name = "idx_gen_1", columnList = "provisioning_contents_id", unique = false)],
+    indexes = [
+        Index(name = "idx_gen_1", columnList = "provisioning_contents_id", unique = false),
+        Index(name = "idx_gen_2", columnList = "created_at DESC"),
+    ],
 )
 data class Gen( // TODO: DB컬럼 타입 변경 필요
     @Id

--- a/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
@@ -12,20 +12,13 @@ interface GenRepository : JpaRepository<Gen, Long> {
 
     @Query(
         """
-    SELECT * FROM (
-        SELECT *, ROW_NUMBER() OVER (ORDER BY created_at DESC) AS rn
-        FROM gen
-    ) ranked
-    WHERE rn > (
-        SELECT target_rn FROM (
-            SELECT id, ROW_NUMBER() OVER (ORDER BY created_at DESC) AS target_rn
-            FROM gen
-        ) sub
-        WHERE sub.id = :targetId
-    )
-    ORDER BY rn
-    LIMIT :limitSize
-    """,
+        SELECT g.* FROM gen g
+        WHERE g.created_at < (
+            SELECT created_at FROM gen WHERE id = :targetId
+        )
+        ORDER BY g.created_at DESC
+        LIMIT :pageSize
+        """,
         nativeQuery = true,
     )
     fun findNextLimit(

--- a/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
@@ -17,7 +17,7 @@ interface GenRepository : JpaRepository<Gen, Long> {
             SELECT created_at FROM gen WHERE id = :targetId
         )
         ORDER BY g.created_at DESC
-        LIMIT :pageSize
+        LIMIT :limitSize
         """,
         nativeQuery = true,
     )

--- a/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
@@ -2,9 +2,34 @@ package com.few.generator.repository
 
 import com.few.generator.domain.Gen
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface GenRepository : JpaRepository<Gen, Long> {
     fun findByProvisioningContentsId(provisioningContentsId: Long): List<Gen>
 
     fun existsByProvisioningContentsId(provisioningContentsId: Long): Boolean
+
+    @Query(
+        """
+    SELECT * FROM (
+        SELECT *, ROW_NUMBER() OVER (ORDER BY created_at DESC) AS rn
+        FROM gen
+    ) ranked
+    WHERE rn > (
+        SELECT target_rn FROM (
+            SELECT id, ROW_NUMBER() OVER (ORDER BY created_at DESC) AS target_rn
+            FROM gen
+        ) sub
+        WHERE sub.id = :targetId
+    )
+    ORDER BY rn
+    LIMIT :pageSize
+    """,
+        nativeQuery = true,
+    )
+    fun findNext20After(
+        @Param("targetId") targetId: Long,
+        @Param("pageSize") pageSize: Int,
+    ): List<Gen>
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
@@ -28,7 +28,7 @@ interface GenRepository : JpaRepository<Gen, Long> {
     """,
         nativeQuery = true,
     )
-    fun findNextLimitAfter(
+    fun findNextLimit(
         @Param("targetId") targetId: Long,
         @Param("limitSize") limitSize: Int,
     ): List<Gen>
@@ -37,7 +37,7 @@ interface GenRepository : JpaRepository<Gen, Long> {
         "SELECT * FROM gen ORDER BY created_at DESC LIMIT :limitSize",
         nativeQuery = true,
     )
-    fun findFirstLimitAfter(
+    fun findFirstLimit(
         @Param("limitSize") limitSize: Int,
     ): List<Gen>
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
@@ -34,7 +34,7 @@ interface GenRepository : JpaRepository<Gen, Long> {
     ): List<Gen>
 
     @Query(
-        "SELECT * FROM gen ORDER BY id DESC LIMIT :limitSize",
+        "SELECT * FROM gen ORDER BY created_at DESC LIMIT :limitSize",
         nativeQuery = true,
     )
     fun findFirstLimitAfter(

--- a/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
@@ -24,12 +24,20 @@ interface GenRepository : JpaRepository<Gen, Long> {
         WHERE sub.id = :targetId
     )
     ORDER BY rn
-    LIMIT :pageSize
+    LIMIT :limitSize
     """,
         nativeQuery = true,
     )
-    fun findNext20After(
+    fun findNextLimitAfter(
         @Param("targetId") targetId: Long,
-        @Param("pageSize") pageSize: Int,
+        @Param("limitSize") limitSize: Int,
+    ): List<Gen>
+
+    @Query(
+        "SELECT * FROM gen ORDER BY id DESC LIMIT :limitSize",
+        nativeQuery = true,
+    )
+    fun findFirstLimitAfter(
+        @Param("limitSize") limitSize: Int,
     ): List<Gen>
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
@@ -1,14 +1,22 @@
 package com.few.generator.usecase
 
 import com.few.generator.config.GeneratorGsonConfig.Companion.GSON_BEAN_NAME
+import com.few.generator.domain.Category
+import com.few.generator.domain.MediaType
 import com.few.generator.repository.GenRepository
 import com.few.generator.repository.ProvisioningContentsRepository
 import com.few.generator.repository.RawContentsRepository
 import com.few.generator.support.jpa.GeneratorTransactional
 import com.few.generator.usecase.out.BrowseContentsUsecaseOuts
+import com.few.generator.usecase.out.ContentsUsecaseOut
 import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import kotlin.Int
+import kotlin.String
 
 @Component
 data class BrowseContentsUseCase(
@@ -17,9 +25,44 @@ data class BrowseContentsUseCase(
     private val genRepository: GenRepository,
     @Qualifier(GSON_BEAN_NAME)
     private val gson: Gson,
+    @Value("\${generator.contents.pageSize}")
+    private val pageSize: Int,
 ) {
     @GeneratorTransactional(readOnly = true)
     fun execute(prevContentId: Long): BrowseContentsUsecaseOuts {
-        TODO()
+        val gens = genRepository.findNext20After(prevContentId, pageSize)
+
+        if (gens.isEmpty()) {
+            return BrowseContentsUsecaseOuts(
+                contents = emptyList(),
+                isLast = true,
+            )
+        }
+
+        val joinedContents =
+            gens.mapNotNull { gen ->
+                val provisioning = provisioningContentsRepository.findById(gen.provisioningContentsId).orElse(null)
+                val rawContentsId = provisioning?.rawContentsId ?: return@mapNotNull null
+                val rawContents = rawContentsRepository.findById(rawContentsId).orElse(null)
+                if (rawContents != null) Triple(gen, provisioning, rawContents) else null
+            }
+
+        return BrowseContentsUsecaseOuts(
+            contents =
+                joinedContents.map { (gen, _, raw) ->
+                    ContentsUsecaseOut(
+                        id = gen.id!!,
+                        url = raw.url,
+                        thumbnailImageUrl = raw.thumbnailImageUrl,
+                        mediaType = MediaType.from(raw.mediaType),
+                        headline = gen.headline,
+                        summary = gen.summary,
+                        highlightTexts = gson.fromJson(gen.highlightTexts, object : TypeToken<List<String>>() {}.type),
+                        createdAt = gen.createdAt ?: LocalDateTime.MIN,
+                        category = Category.from(raw.category),
+                    )
+                },
+            isLast = gens.size < pageSize,
+        )
     }
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
@@ -32,9 +32,9 @@ data class BrowseContentsUseCase(
     fun execute(prevContentId: Long): BrowseContentsUsecaseOuts {
         val gens =
             if (prevContentId == -1L) {
-                genRepository.findFirstLimitAfter(pageSize)
+                genRepository.findFirstLimit(pageSize)
             } else {
-                genRepository.findNextLimitAfter(prevContentId, pageSize)
+                genRepository.findNextLimit(prevContentId, pageSize)
             }
 
         if (gens.isEmpty()) {

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
@@ -30,7 +30,12 @@ data class BrowseContentsUseCase(
 ) {
     @GeneratorTransactional(readOnly = true)
     fun execute(prevContentId: Long): BrowseContentsUsecaseOuts {
-        val gens = genRepository.findNext20After(prevContentId, pageSize)
+        val gens =
+            if (prevContentId == -1L) {
+                genRepository.findFirstLimitAfter(pageSize)
+            } else {
+                genRepository.findNextLimitAfter(prevContentId, pageSize)
+            }
 
         if (gens.isEmpty()) {
             return BrowseContentsUsecaseOuts(

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
@@ -1,0 +1,25 @@
+package com.few.generator.usecase
+
+import com.few.generator.config.GeneratorGsonConfig.Companion.GSON_BEAN_NAME
+import com.few.generator.repository.GenRepository
+import com.few.generator.repository.ProvisioningContentsRepository
+import com.few.generator.repository.RawContentsRepository
+import com.few.generator.support.jpa.GeneratorTransactional
+import com.few.generator.usecase.out.BrowseContentsUsecaseOuts
+import com.google.gson.Gson
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+
+@Component
+data class BrowseContentsUseCase(
+    private val rawContentsRepository: RawContentsRepository,
+    private val provisioningContentsRepository: ProvisioningContentsRepository,
+    private val genRepository: GenRepository,
+    @Qualifier(GSON_BEAN_NAME)
+    private val gson: Gson,
+) {
+    @GeneratorTransactional(readOnly = true)
+    fun execute(prevContentId: Long): BrowseContentsUsecaseOuts {
+        TODO()
+    }
+}

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/out/BrowseContentsUsecaseOuts.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/out/BrowseContentsUsecaseOuts.kt
@@ -10,7 +10,7 @@ data class BrowseContentsUsecaseOuts(
 )
 
 data class ContentsUsecaseOut(
-    val id: Int,
+    val id: Long,
     val url: String,
     val thumbnailImageUrl: String?,
     val mediaType: MediaType,

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/out/BrowseContentsUsecaseOuts.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/out/BrowseContentsUsecaseOuts.kt
@@ -1,0 +1,22 @@
+package com.few.generator.usecase.out
+
+import com.few.generator.domain.Category
+import com.few.generator.domain.MediaType
+import java.time.LocalDateTime
+
+data class BrowseContentsUsecaseOuts(
+    val contents: List<ContentsUsecaseOut>,
+    val isLast: Boolean,
+)
+
+data class ContentsUsecaseOut(
+    val id: Int,
+    val url: String,
+    val thumbnailImageUrl: String?,
+    val mediaType: MediaType,
+    val headline: String,
+    val summary: String,
+    val highlightTexts: List<String>,
+    val createdAt: LocalDateTime,
+    val category: Category,
+)

--- a/domain/generator/src/main/resources/application-generator-local.yaml
+++ b/domain/generator/src/main/resources/application-generator-local.yaml
@@ -51,3 +51,4 @@ generator:
         defaultRetryAfter: 60
     contents:
         countByCategory: 1
+        pageSize: 20

--- a/domain/generator/src/main/resources/application-generator-prd.yaml
+++ b/domain/generator/src/main/resources/application-generator-prd.yaml
@@ -51,3 +51,4 @@ generator:
         defaultRetryAfter: 60
     contents:
         countByCategory: 10
+        pageSize: 20

--- a/library/common/src/main/kotlin/common/config/JacksonConfig.kt
+++ b/library/common/src/main/kotlin/common/config/JacksonConfig.kt
@@ -1,6 +1,7 @@
 package common.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -11,6 +12,7 @@ class JacksonConfig {
     fun objectMapper(): ObjectMapper {
         val mapper = ObjectMapper()
         mapper.registerModule(JavaTimeModule())
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         return mapper
     }
 }

--- a/library/web/src/main/kotlin/web/security/config/ProdDelegatedSecurityConfigurer.kt
+++ b/library/web/src/main/kotlin/web/security/config/ProdDelegatedSecurityConfigurer.kt
@@ -111,6 +111,12 @@ class ProdDelegatedSecurityConfigurer(
                      * TODO: view는 우선 시큐리티 미적용
                      * */
                     AntPathRequestMatcher("/view/**"),
+                    /**
+                     * generator
+                     */
+                    AntPathRequestMatcher("/api/v1/contents"),
+                    AntPathRequestMatcher("/api/v1/contents/**"),
+                    AntPathRequestMatcher("/api/v1/rawcontents/**"),
                 )
         }
 }


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #669 

💁‍♂️ PR 내용
----
- 컨텐츠 조회 무한 스크롤 추가
- URL param으로 prevContentId를 준다(이전 요청의 마지막 컨텐츠 ID)
    - 만약 prevContentId를 주지 않은 경우 첫 번째 페이지로 간주한다

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----
첫 번쨰 페이지는 prevContentId를 주지 않거나 -1로 줍니다

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/11d0933a-8555-4808-823e-b9af78d7db18" />




🚩 추가된 SQL 운영계 실행계획
---

### 페이징 쿼리 1번안
![image](https://github.com/user-attachments/assets/52729bc8-a530-4eb2-b997-ab1b492ecf8b)

```
-> Limit: 20 row(s)  (cost=2.6..2.6 rows=0) (actual time=4.15..4.18 rows=20 loops=1)
    -> Sort: ranked.rn, limit input to 20 row(s) per chunk  (cost=2.6..2.6 rows=0) (actual time=4.15..4.18 rows=20 loops=1)
        -> Filter: (ranked.rn > (select #3))  (cost=2.5..2.5 rows=0) (actual time=3.94..4.03 rows=295 loops=1)
            -> Table scan on ranked  (cost=2.5..2.5 rows=0) (actual time=1.94..2 rows=300 loops=1)
                -> Materialize  (cost=0..0 rows=0) (actual time=1.94..1.94 rows=300 loops=1)
                    -> Window aggregate: row_number() OVER (ORDER BY gen.created_at desc )   (actual time=0.512..1.12 rows=300 loops=1)
                        -> Sort: gen.created_at DESC  (cost=33.2 rows=300) (actual time=0.502..0.938 rows=300 loops=1)
                            -> Table scan on gen  (cost=33.2 rows=300) (actual time=0.0335..0.297 rows=300 loops=1)
            -> Select #3 (subquery in condition; run only once)
                -> Index lookup on sub using <auto_key0> (id=296)  (cost=0.35..3.5 rows=10) (actual time=1.98..1.98 rows=1 loops=1)
                    -> Materialize  (cost=0..0 rows=0) (actual time=1.97..1.97 rows=300 loops=1)
                        -> Window aggregate: row_number() OVER (ORDER BY gen.created_at desc )   (actual time=1.63..1.69 rows=300 loops=1)
                            -> Sort: gen.created_at DESC  (cost=33.2 rows=300) (actual time=1.63..1.64 rows=300 loops=1)
                                -> Table scan on gen  (cost=33.2 rows=300) (actual time=0.0351..0.133 rows=300 loops=1)

```

-> **테이블 크기가 많지 않아 테이블 스캔하는것 같은데 검증계 반영후 다시 추출 필요**

### 페이징 쿼리 2번안
<img width="1402" alt="image" src="https://github.com/user-attachments/assets/e5f891f6-dabb-4b99-bc1a-1facd0eba925" />

```
-> Limit: 20 row(s)  (cost=15.7 rows=20) (actual time=0.481..0.51 rows=20 loops=1)
    -> Sort: g.created_at DESC, limit input to 20 row(s) per chunk  (cost=15.7 rows=350) (actual time=0.481..0.508 rows=20 loops=1)
        -> Filter: (g.created_at < (select #2))  (cost=15.7 rows=350) (actual time=0.0198..0.399 rows=295 loops=1)
            -> Table scan on g  (cost=15.7 rows=350) (actual time=0.0109..0.283 rows=350 loops=1)
            -> Select #2 (subquery in condition; run only once)
                -> Rows fetched before execution  (cost=0..0 rows=1) (actual time=84e-6..143e-6 rows=1 loops=1)
```

-> 우선은 ordering이 필요 없는 이 쿼리로 적용하고 추후 개선 필요하다면 개선 예정. 위 실행계획은 데이터가 적어서 테이블 스캔으로 보이고, 검증계 반영 후 더 봐야할 것 같습니다 

-> gen 테이블에서 인덱스 리오더링이 발생하는 시점은 4시에 스케줄링 도는 시점 뿐이기 때문에 영향도 거의 없음

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **신규 기능**
  - 콘텐츠 목록을 페이지네이션 방식으로 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
- **설정**
  - 콘텐츠 조회 시 한 번에 불러오는 개수(page size)가 20개로 설정되었습니다.
- **보안**
  - 콘텐츠 관련 신규 API가 인증 없이 접근 가능하도록 보안 예외 처리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->