### PR TITLE
[Feat/#695] 카테고리 기반 콘텐츠 조회 기능 추가 및 인덱스 생성

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
@@ -5,6 +5,7 @@ import com.few.generator.domain.Category
 import com.few.generator.usecase.BrowseContentsUseCase
 import com.few.generator.usecase.RawContentsBrowseContentUseCase
 import com.few.generator.usecase.SchedulingUseCase
+import com.few.generator.usecase.`in`.BrowseContentsUseCaseIn
 import jakarta.validation.constraints.Min
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -40,9 +41,16 @@ class ContentsGeneratorController(
             value = "prevContentId",
             required = false,
             defaultValue = "-1",
-        ) prevGenId: Long,
+        )
+        prevGenId: Long,
+        @RequestParam(
+            value = "category",
+            required = false,
+        )
+        categoryCode: Int?,
     ): ApiResponse<ApiResponse.SuccessBody<BrowseContentResponses>> {
-        val ucOuts = browseContentsUseCase.execute(prevGenId)
+        val input = BrowseContentsUseCaseIn(prevGenId, categoryCode)
+        val ucOuts = browseContentsUseCase.execute(input)
 
         val response =
             BrowseContentResponses(
@@ -52,12 +60,20 @@ class ContentsGeneratorController(
                             id = it.id,
                             url = it.url,
                             thumbnailImageUrl = it.thumbnailImageUrl,
-                            mediaType = CodeValueResponse(code = it.mediaType.code, value = it.mediaType.title),
+                            mediaType =
+                                CodeValueResponse(
+                                    code = it.mediaType.code,
+                                    value = it.mediaType.title,
+                                ),
                             headline = it.headline,
                             summary = it.summary,
                             highlightTexts = it.highlightTexts,
                             createdAt = it.createdAt,
-                            category = CodeValueResponse(code = it.category.code, value = it.category.title),
+                            category =
+                                CodeValueResponse(
+                                    code = it.category.code,
+                                    value = it.category.title,
+                                ),
                         )
                     },
                 isLast = ucOuts.isLast,
@@ -68,9 +84,7 @@ class ContentsGeneratorController(
 
     @GetMapping(value = ["/contents/{id}"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getByRawContents(
-        @PathVariable(value = "id")
-        @Min(value = 1, message = "{min.id}")
-        genId: Long,
+        @PathVariable(value = "id") @Min(value = 1, message = "{min.id}") genId: Long,
     ): ApiResponse<ApiResponse.SuccessBody<BrowseContentsResponse>> {
         val useCaseOut = rawContentsBrowseContentUseCase.execute(genId)
 
@@ -82,29 +96,43 @@ class ContentsGeneratorController(
                         url = useCaseOut.rawContents.url,
                         title = useCaseOut.rawContents.title,
                         description = useCaseOut.rawContents.description,
-                        thumbnailImageUrl = useCaseOut.rawContents.thumbnailImageUrl,
+                        thumbnailImageUrl =
+                            useCaseOut.rawContents.thumbnailImageUrl,
                         rawTexts = useCaseOut.rawContents.rawTexts,
                         imageUrls = useCaseOut.rawContents.imageUrls,
                         mediaType =
                             CodeValueResponse(
-                                code = useCaseOut.rawContents.mediaType.code,
-                                value = useCaseOut.rawContents.mediaType.title,
+                                code =
+                                    useCaseOut
+                                        .rawContents
+                                        .mediaType
+                                        .code,
+                                value =
+                                    useCaseOut
+                                        .rawContents
+                                        .mediaType
+                                        .title,
                             ),
                         createdAt = useCaseOut.rawContents.createdAt,
                     ),
                 provisioningContents =
                     BrowseProvisioningContentsResponse(
                         id = useCaseOut.provisioningContents.id,
-                        rawContentsId = useCaseOut.provisioningContents.rawContentsId,
-                        completionIds = useCaseOut.provisioningContents.completionIds,
-                        bodyTextsJson = useCaseOut.provisioningContents.bodyTextsJson,
-                        coreTextsJson = useCaseOut.provisioningContents.coreTextsJson,
+                        rawContentsId =
+                            useCaseOut.provisioningContents.rawContentsId,
+                        completionIds =
+                            useCaseOut.provisioningContents.completionIds,
+                        bodyTextsJson =
+                            useCaseOut.provisioningContents.bodyTextsJson,
+                        coreTextsJson =
+                            useCaseOut.provisioningContents.coreTextsJson,
                         createdAt = useCaseOut.provisioningContents.createdAt,
                     ),
                 gen =
                     BrowseGenResponse(
                         id = useCaseOut.gen.id,
-                        provisioningContentsId = useCaseOut.gen.provisioningContentsId,
+                        provisioningContentsId =
+                            useCaseOut.gen.provisioningContentsId,
                         completionIds = useCaseOut.gen.completionIds,
                         headline = useCaseOut.gen.headline,
                         summary = useCaseOut.gen.summary,
@@ -124,9 +152,7 @@ class ContentsGeneratorController(
     @GetMapping(value = ["/contents/categories"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getProvisioningCategories(): ApiResponse<ApiResponse.SuccessBody<List<CodeValueResponse>>> =
         ApiResponseGenerator.success(
-            Category.entries.map {
-                CodeValueResponse(code = it.code, value = it.title)
-            },
+            Category.entries.map { CodeValueResponse(code = it.code, value = it.title) },
             HttpStatus.OK,
         )
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/domain/Gen.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/domain/Gen.kt
@@ -6,36 +6,36 @@ import jakarta.persistence.*
 @Entity
 @Table(
     name = "gen",
-    indexes = [
-        Index(name = "idx_gen_1", columnList = "provisioning_contents_id", unique = false),
-        Index(name = "idx_gen_2", columnList = "created_at DESC"),
-    ],
+    indexes =
+        [
+            Index(
+                name = "idx_gen_1",
+                columnList = "provisioning_contents_id",
+                unique = false,
+            ),
+            Index(name = "idx_gen_2", columnList = "created_at DESC"),
+            Index(name = "idx_gen_3", columnList = "category", unique = false),
+        ],
 )
 data class Gen( // TODO: DB컬럼 타입 변경 필요
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
-    @Column(nullable = false)
-    val provisioningContentsId: Long,
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Long? = null,
+    @Column(nullable = false) val provisioningContentsId: Long,
     @Convert(converter = MutableListJsonConverter::class)
     @Column(columnDefinition = "TEXT", nullable = false)
     val completionIds: MutableList<String> = mutableListOf(),
-    @Column(columnDefinition = "TEXT", nullable = false)
-    val headline: String,
-    @Column(columnDefinition = "TEXT", nullable = false)
-    val summary: String,
-    @Column(columnDefinition = "TEXT", nullable = false)
-    val highlightTexts: String = "[]",
-    @Column(nullable = false)
-    val category: Int,
+    @Column(columnDefinition = "TEXT", nullable = false) val headline: String,
+    @Column(columnDefinition = "TEXT", nullable = false) val summary: String,
+    @Column(columnDefinition = "TEXT", nullable = false) val highlightTexts: String = "[]",
+    @Column(nullable = false) val category: Int,
 ) : BaseEntity() {
-    protected constructor() : this( // TODO: 기본 생성자 필요?
-        id = null,
-        provisioningContentsId = 0L,
-        completionIds = mutableListOf(),
-        headline = "",
-        summary = "",
-        highlightTexts = "[]",
-        category = 0,
-    )
+    protected constructor() :
+        this( // TODO: 기본 생성자 필요?
+            id = null,
+            provisioningContentsId = 0L,
+            completionIds = mutableListOf(),
+            headline = "",
+            summary = "",
+            highlightTexts = "[]",
+            category = 0,
+        )
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
@@ -31,4 +31,31 @@ interface GenRepository : JpaRepository<Gen, Long> {
     fun findFirstLimit(
         @Param("limitSize") limitSize: Int,
     ): List<Gen>
+
+    @Query(
+        """
+        SELECT g.* FROM gen g
+        WHERE g.category = :category
+        AND g.created_at < (
+            SELECT created_at FROM gen WHERE id = :targetId
+        )
+        ORDER BY g.created_at DESC
+        LIMIT :limitSize
+        """,
+        nativeQuery = true,
+    )
+    fun findNextLimitByCategory(
+        @Param("targetId") targetId: Long,
+        @Param("category") category: Int,
+        @Param("limitSize") limitSize: Int,
+    ): List<Gen>
+
+    @Query(
+        "SELECT * FROM gen WHERE category = :category ORDER BY created_at DESC LIMIT :limitSize",
+        nativeQuery = true,
+    )
+    fun findFirstLimitByCategory(
+        @Param("category") category: Int,
+        @Param("limitSize") limitSize: Int,
+    ): List<Gen>
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/in/BrowseContentsUseCaseIn.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/in/BrowseContentsUseCaseIn.kt
@@ -1,0 +1,20 @@
+package com.few.generator.usecase.`in`
+
+import com.few.generator.domain.Category
+import web.handler.exception.BadRequestException
+
+data class BrowseContentsUseCaseIn(
+    val prevGenId: Long,
+    val categoryCode: Int? = null,
+) {
+    init {
+        // 카테고리 코드 유효성 검증
+        if (categoryCode != null) {
+            try {
+                Category.from(categoryCode)
+            } catch (e: Exception) {
+                throw BadRequestException("Invalid category code: $categoryCode")
+            }
+        }
+    }
+}


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #695 

💁‍♂️ PR 내용
----

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/f61558ba-0afb-47d7-b41a-6ef5eb2833b1" />


🚩 추가된 SQL 운영계 실행계획
---

<img width="658" alt="image" src="https://github.com/user-attachments/assets/4d291637-1a40-4620-a353-f432b5f89a56" />

```
-> Limit: 20 row(s) (cost=4.77 rows=20) (actual time=0.105..0.130 rows=19 loops=1) -> Sort: g.created_at DESC, limit input to 20 row(s) per chunk (cost=4.77 rows=21) (actual time=0.103..0.126 rows=19 loops=1) -> Filter: (g.created_at < (select #2)) (actual time=0.024..0.074 rows=19 loops=1) -> Index lookup on g using idx_gen_3 (category=2) (actual time=0.021..0.062 rows=21 loops=1) -> Select #2 (subquery in condition; run only once) -> Rows fetched before execution (cost=0.00..0.00 rows=1) (actual time=0.000..0.000 rows=1 loops=1)
```

-> **Index lookup on g using idx_gen_3 (category=2)** 확인

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
