### PR TITLE
[Fix/#698] title 스크래핑 개선 2차

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/naver/NaverExtractor.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/naver/NaverExtractor.kt
@@ -65,6 +65,7 @@ object NaverExtractor {
                 regexMatches.group(1)?.takeIf { isValidImageUrl(it) }?.let { imageUrls.add(it) }
             }
             return imageUrls
+                .filter { true }
                 .filter { it.startsWith("http://") || it.startsWith("https://") }
                 .toList()
         }

--- a/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/naver/NaverScrapper.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/naver/NaverScrapper.kt
@@ -63,11 +63,16 @@ class NaverScrapper(
     private fun removeMediaTypeTitleSuffix(title: String?): String? {
         if (title == null) return null
 
-        val trimmedtitle = title.trim()
+        var trimmedtitle = title.trim()
         for (mediaType in MediaType.entries) {
             if (mediaType == MediaType.ETC) continue
             if (trimmedtitle.endsWith(mediaType.title)) {
-                return trimmedtitle.removeSuffix(mediaType.title).trim()
+                trimmedtitle = trimmedtitle.removeSuffix(mediaType.title).trim()
+                return if (trimmedtitle.endsWith("|") || trimmedtitle.endsWith("-")) {
+                    trimmedtitle.dropLast(1)
+                } else {
+                    trimmedtitle
+                }
             }
         }
 

--- a/domain/generator/src/main/kotlin/com/few/generator/domain/MediaType.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/domain/MediaType.kt
@@ -11,7 +11,7 @@ enum class MediaType(
     KHAN(2, "경향신문", listOf("khan")),
     SBS(3, "SBS", listOf("sbs")),
     HANKYUNG(4, "한국경제", listOf("hankyung")),
-    YONHAPNEWS(5, "연합뉴스TV", listOf("yonhapnews", "yna.co.kr")),
+    YONHAPNEWS_TV(5, "연합뉴스TV", listOf("yonhapnews", "yna.co.kr")),
     DONGA(6, "동아일보", listOf("donga")),
     I_NEWS(7, "아이뉴스", listOf("inews")),
     FN_NEWS(8, "파이낸셜뉴스", listOf("fnnews")),
@@ -43,6 +43,9 @@ enum class MediaType(
     MK(34, "매일경제", listOf("mk.co.kr")),
     BLOTTER(35, "블로터", listOf("bloter.net")),
     ETNEWS(36, "전자신문", listOf("etnews.com")),
+    YONHAPNEWS(37, "연합뉴스", listOf("yonhapnews", "yna.co.kr")),
+    MAEIL(38, "매일신문", listOf("imaeil.com")),
+    JOSEILBO(39, "조세일보", listOf("joseilbo.com")),
     ETC(0, "ETC", emptyList()),
 
     ;


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #698 

💁‍♂️ PR 내용
----
- 매일신문 - imaeil.com, 조세일보 - joseilbo.com MediaType 추가
- 타이틀 마지막이 | 또는 - 인 경우 삭제

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * "연합뉴스", "매일신문", "조세일보" 미디어 유형이 추가되었습니다.

* **버그 수정**
  * 미디어 유형 접미사 제거 시 남는 구분자(‘|’, ‘-’)가 자동으로 정리되어 제목이 더 깔끔하게 표시됩니다.

* **스타일**
  * 기존 "연합뉴스TV" 미디어 유형의 명칭이 "YONHAPNEWS_TV"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->