### PR TITLE
[Test/#711] Gen 관련 테스트 코드 작성

### DIFF
--- a/domain/generator/build.gradle.kts
+++ b/domain/generator/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    `java-test-fixtures`
+}
+
 tasks.getByName("bootJar") {
     enabled = false
 }
@@ -24,4 +28,47 @@ dependencies {
 
     /** gson **/
     implementation("com.google.code.gson:gson:${DependencyVersion.GSON}")
+
+    /** test */
+    testFixturesImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter-kotlin:1.0.15")
+}
+
+// generator 모듈 특화 JaCoCo 설정 - 점진적 커버리지 향상
+tasks.jacocoTestCoverageVerification {
+    isEnabled = false // 초기 단계에서는 비활성화, 커버리지 리포트만 생성
+    violationRules {
+        // 미래 사용을 위한 설정 (enabled = false로 비활성화 상태)
+        rule {
+            enabled = false
+            element = "CLASS"
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.70".toBigDecimal()
+            }
+            includes =
+                listOf(
+                    "com.few.generator.controller.*",
+                    "com.few.generator.usecase.*",
+                )
+            excludes =
+                listOf(
+                    "*.*Test*",
+                    "*.*Fixture*",
+                    "*.*TestData*",
+                    "*\$*\$*",
+                    "*.usecase.input.*",
+                    "*.usecase.out.*",
+                )
+        }
+        rule {
+            enabled = false
+            element = "BUNDLE"
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.30".toBigDecimal()
+            }
+        }
+    }
 }

--- a/domain/generator/src/test/kotlin/com/few/generator/TestConfig.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/TestConfig.kt
@@ -1,0 +1,9 @@
+package com.few.generator
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+import io.kotest.extensions.spring.SpringExtension
+
+class TestConfig : AbstractProjectConfig() {
+    override fun extensions(): List<Extension> = listOf(SpringExtension)
+}

--- a/domain/generator/src/test/kotlin/com/few/generator/controller/ContentsGeneratorControllerTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/controller/ContentsGeneratorControllerTest.kt
@@ -1,0 +1,231 @@
+package com.few.generator.controller
+
+import com.few.generator.domain.Category
+import com.few.generator.fixture.usecase.BrowseContentsFixture
+import com.few.generator.fixture.usecase.BrowseDetailFixture
+import com.few.generator.fixture.usecase.BrowseGroupGenResponsesFixture
+import com.few.generator.service.GroupGenService
+import com.few.generator.usecase.BrowseContentsUseCase
+import com.few.generator.usecase.GroupGenBrowseUseCase
+import com.few.generator.usecase.RawContentsBrowseContentUseCase
+import com.few.generator.usecase.SchedulingUseCase
+import com.few.generator.usecase.input.BrowseContentsUseCaseIn
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+import org.springframework.http.MediaType as SpringMediaType
+
+class ContentsGeneratorControllerTest :
+    DescribeSpec({
+
+        val schedulingUseCase = mockk<SchedulingUseCase>()
+        val rawContentsBrowseContentUseCase = mockk<RawContentsBrowseContentUseCase>()
+        val browseContentsUseCase = mockk<BrowseContentsUseCase>()
+        val groupGenService = mockk<GroupGenService>()
+        val groupGenBrowseUseCase = mockk<GroupGenBrowseUseCase>()
+
+        val controller =
+            ContentsGeneratorController(
+                schedulingUseCase,
+                rawContentsBrowseContentUseCase,
+                browseContentsUseCase,
+                groupGenService,
+                groupGenBrowseUseCase,
+            )
+
+        val mockMvc: MockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+
+        describe("ContentsGeneratorController") {
+
+            describe("POST /api/v1/contents/schedule") {
+                it("콘텐츠 스케줄링을 실행한다") {
+                    every { schedulingUseCase.execute() } returns Unit
+
+                    mockMvc
+                        .perform(
+                            post("/api/v1/contents/schedule")
+                                .contentType(SpringMediaType.APPLICATION_JSON),
+                        ).andExpect(status().isOk)
+
+                    verify { schedulingUseCase.execute() }
+                }
+            }
+
+            describe("POST /api/v1/contents/groups/schedule") {
+                it("그룹 콘텐츠 스케줄링을 실행한다") {
+                    every { groupGenService.createAllGroupGen() } returns emptyList()
+
+                    mockMvc
+                        .perform(
+                            post("/api/v1/contents/groups/schedule")
+                                .contentType(SpringMediaType.APPLICATION_JSON),
+                        ).andExpect(status().isOk)
+                        .andExpect(jsonPath("$.message").value("성공"))
+
+                    verify { groupGenService.createAllGroupGen() }
+                }
+            }
+
+            describe("GET /api/v1/contents") {
+                it("기본 파라미터로 콘텐츠 목록을 조회한다") {
+                    val expectedInput = BrowseContentsUseCaseIn(-1L, null)
+                    val useCaseOutput = BrowseContentsFixture.default().sample()
+                    every { browseContentsUseCase.execute(expectedInput) } returns useCaseOutput
+
+                    mockMvc
+                        .perform(
+                            get("/api/v1/contents")
+                                .param("prevContentId", "-1"),
+                        ).andExpect(status().isOk)
+                        .andExpect(jsonPath("$.message").value("성공"))
+                        .andExpect(jsonPath("$.data.contents").isNotEmpty)
+                        .andExpect(jsonPath("$.data.contents[0].id").value(1))
+                        .andExpect(jsonPath("$.data.contents[0].headline").value("테스트 헤드라인"))
+                        .andExpect(jsonPath("$.data.contents[0].summary").value("테스트 요약"))
+                        .andExpect(jsonPath("$.data.contents[0].highlightTexts[0]").value("하이라이트1"))
+                        .andExpect(jsonPath("$.data.contents[0].highlightTexts[1]").value("하이라이트2"))
+                        .andExpect(jsonPath("$.data.contents[0].mediaType.code").value(1))
+                        .andExpect(
+                            jsonPath("$.data.contents[0].mediaType.value").value("조선일보"),
+                        ).andExpect(
+                            jsonPath("$.data.contents[0].category.code").value(2),
+                        ).andExpect(
+                            jsonPath("$.data.contents[0].category.value").value("기술"),
+                        ).andExpect(jsonPath("$.data.isLast").value(false))
+
+                    verify { browseContentsUseCase.execute(expectedInput) }
+                }
+
+                it("카테고리 파라미터와 함께 콘텐츠 목록을 조회한다") {
+                    val expectedInput = BrowseContentsUseCaseIn(5L, 2)
+                    val useCaseOutput = BrowseContentsFixture.empty().sample()
+                    every { browseContentsUseCase.execute(expectedInput) } returns useCaseOutput
+
+                    mockMvc
+                        .perform(
+                            get("/api/v1/contents")
+                                .param("prevContentId", "5")
+                                .param("category", "2"),
+                        ).andExpect(status().isOk)
+                        .andExpect(jsonPath("$.message").value("성공"))
+                        .andExpect(jsonPath("$.data.contents").isEmpty)
+                        .andExpect(jsonPath("$.data.isLast").value(true))
+
+                    verify { browseContentsUseCase.execute(expectedInput) }
+                }
+
+                it("여러 콘텐츠가 있을 때 올바르게 반환한다") {
+                    val expectedInput = BrowseContentsUseCaseIn(-1L, null)
+                    val useCaseOutput = BrowseContentsFixture.multiple().sample()
+                    every { browseContentsUseCase.execute(expectedInput) } returns useCaseOutput
+
+                    mockMvc
+                        .perform(
+                            get("/api/v1/contents")
+                                .param("prevContentId", "-1"),
+                        ).andExpect(status().isOk)
+                        .andExpect(jsonPath("$.data.contents.length()").value(2))
+                        .andExpect(jsonPath("$.data.contents[0].headline").value("첫 번째 뉴스"))
+                        .andExpect(jsonPath("$.data.contents[1].headline").value("두 번째 뉴스"))
+                        .andExpect(
+                            jsonPath("$.data.contents[0].mediaType.value").value("조선일보"),
+                        ).andExpect(
+                            jsonPath("$.data.contents[1].mediaType.value").value("경향신문"),
+                        ).andExpect(
+                            jsonPath("$.data.contents[0].category.value").value("기술"),
+                        ).andExpect(jsonPath("$.data.contents[1].category.value").value("생활"))
+                        .andExpect(jsonPath("$.data.isLast").value(false))
+
+                    verify { browseContentsUseCase.execute(expectedInput) }
+                }
+            }
+
+            describe("GET /api/v1/contents/{id}") {
+                it("특정 ID로 상세 콘텐츠를 조회한다") {
+                    val contentId = 1L
+                    val useCaseOutput = BrowseDetailFixture.giveMeDefault().build()
+                    every { rawContentsBrowseContentUseCase.execute(contentId) } returns useCaseOutput
+
+                    mockMvc
+                        .perform(
+                            get("/api/v1/contents/{id}", contentId),
+                        ).andExpect(status().isOk)
+                        .andExpect(jsonPath("$.message").value("성공"))
+                        .andExpect(jsonPath("$.data.rawContents.id").value(201))
+                        .andExpect(jsonPath("$.data.rawContents.title").value("원본 제목"))
+                        .andExpect(jsonPath("$.data.provisioningContents.id").value(101))
+                        .andExpect(jsonPath("$.data.gen.id").value(1))
+                        .andExpect(jsonPath("$.data.gen.headline").value("생성된 헤드라인"))
+
+                    verify { rawContentsBrowseContentUseCase.execute(contentId) }
+                }
+            }
+
+            describe("GET /api/v1/contents/categories") {
+                it("모든 카테고리 목록을 반환한다") {
+                    mockMvc
+                        .perform(
+                            get("/api/v1/contents/categories"),
+                        ).andExpect(status().isOk)
+                        .andExpect(jsonPath("$.message").value("성공"))
+                        .andExpect(jsonPath("$.data").isArray)
+                        .andExpect(jsonPath("$.data.length()").value(Category.entries.size))
+                        .andExpect(
+                            jsonPath("$.data[?(@.value == '기술')].code").value(2),
+                        ).andExpect(jsonPath("$.data[?(@.value == '생활')].code").value(4))
+                        .andExpect(
+                            jsonPath("$.data[?(@.value == '정치')].code").value(8),
+                        ).andExpect(jsonPath("$.data[?(@.value == '경제')].code").value(16))
+                        .andExpect(jsonPath("$.data[?(@.value == '사회')].code").value(32))
+                        .andExpect(jsonPath("$.data[?(@.value == '기타')].code").value(0))
+                }
+            }
+
+            describe("GET /api/v1/contents/groups") {
+                it("기본 파라미터로 그룹 콘텐츠 목록을 조회한다") {
+                    val useCaseOutput = BrowseGroupGenResponsesFixture.default().sample()
+                    every { groupGenBrowseUseCase.execute(null) } returns useCaseOutput
+
+                    mockMvc
+                        .perform(
+                            get("/api/v1/contents/groups"),
+                        ).andExpect(status().isOk)
+                        .andExpect(jsonPath("$.message").value("성공"))
+                        .andExpect(jsonPath("$.data.groups").isNotEmpty)
+                        .andExpect(jsonPath("$.data.groups[0].id").value(1))
+                        .andExpect(jsonPath("$.data.groups[0].category").value(2))
+                        .andExpect(jsonPath("$.data.groups[0].headline").value("그룹 헤드라인"))
+                        .andExpect(jsonPath("$.data.groups[0].summary").value("그룹 요약"))
+                        .andExpect(jsonPath("$.data.groups[0].highlightTexts[0]").value("그룹 하이라이트1"))
+                        .andExpect(jsonPath("$.data.groups[0].highlightTexts[1]").value("그룹 하이라이트2"))
+                        .andExpect(jsonPath("$.data.groups[0].groupSourceHeadlines").isArray)
+                        .andExpect(jsonPath("$.data.groups[0].groupSourceHeadlines[0].headline").value("소스 헤드라인1"))
+                        .andExpect(jsonPath("$.data.groups[0].groupSourceHeadlines[0].url").value("https://example.com/1"))
+
+                    verify { groupGenBrowseUseCase.execute(null) }
+                }
+
+                it("날짜 파라미터와 함께 그룹 콘텐츠 목록을 조회한다") {
+                    val date = LocalDate.of(2023, 5, 15)
+                    val useCaseOutput = BrowseGroupGenResponsesFixture.empty().sample()
+                    every { groupGenBrowseUseCase.execute(date) } returns useCaseOutput
+
+                    mockMvc
+                        .perform(
+                            get("/api/v1/contents/groups")
+                                .param("date", "2023-05-15"),
+                        ).andExpect(status().isOk)
+                        .andExpect(jsonPath("$.message").value("성공"))
+                        .andExpect(jsonPath("$.data.groups").isEmpty)
+
+                    verify { groupGenBrowseUseCase.execute(date) }
+                }
+            }
+        }
+    })

--- a/domain/generator/src/test/kotlin/com/few/generator/core/gpt/prompt/PromptGeneratorTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/core/gpt/prompt/PromptGeneratorTest.kt
@@ -1,0 +1,83 @@
+package com.few.generator.core.gpt.prompt
+
+import com.google.gson.Gson
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+import io.kotest.matchers.string.shouldContain
+
+// 커스텀 Matcher 정의
+fun beAValidPrompt() =
+    object : Matcher<Prompt> {
+        override fun test(value: Prompt) =
+            MatcherResult(
+                value.messages.size == 2 &&
+                    value.messages[0].role == ROLE.SYSTEM &&
+                    value.messages[1].role == ROLE.USER,
+                { "Prompt should have 2 messages (SYSTEM, USER)" },
+                { "Prompt should not have 2 messages (SYSTEM, USER)" },
+            )
+    }
+
+class PromptGeneratorTest :
+    DescribeSpec({
+
+        val gson = Gson()
+        val promptGenerator = PromptGenerator(gson)
+
+        describe("PromptGenerator") {
+
+            describe("프롬프트 생성") {
+                it("toKoreanKeyWords: 핵심 텍스트로 키워드 프롬프트를 생성한다") {
+                    val coreTexts = "키워드 추출할 핵심 내용입니다."
+                    val prompt = promptGenerator.toKoreanKeyWords(coreTexts)
+
+                    prompt should beAValidPrompt()
+                    prompt.messages[1].content shouldContain coreTexts
+                    prompt.messages[1].content shouldContain "키워드"
+                }
+
+                it("toKoreanHighlightText: 요약으로 하이라이트 프롬프트를 생성한다") {
+                    val summary = "하이라이트할 요약 내용입니다."
+                    val prompt = promptGenerator.toKoreanHighlightText(summary)
+
+                    prompt should beAValidPrompt()
+                    prompt.messages[1].content shouldContain summary
+                    prompt.messages[1].content shouldContain "하이라이트"
+                }
+
+                it("toGroupHeadlineOnlyPrompt: 헤드라인 목록으로 그룹 헤드라인 프롬프트를 생성한다") {
+                    val headlines = listOf("헤드라인1", "헤드라인2", "헤드라인3")
+                    val prompt = promptGenerator.toGroupHeadlineOnlyPrompt(headlines)
+
+                    prompt should beAValidPrompt()
+                    prompt.messages[1].content shouldContain "헤드라인1"
+                    prompt.messages[1].content shouldContain "헤드라인2"
+                    prompt.messages[1].content shouldContain "헤드라인3"
+                }
+
+                it("toGroupHighlightPrompt: 그룹 요약으로 하이라이트 프롬프트를 생성한다") {
+                    val groupSummary = "그룹 요약 내용입니다."
+                    val prompt = promptGenerator.toGroupHighlightPrompt(groupSummary)
+
+                    prompt should beAValidPrompt()
+                    prompt.messages[1].content shouldContain groupSummary
+                    prompt.messages[1].content shouldContain "하이라이트"
+                }
+            }
+
+            describe("프롬프트 구조 검증") {
+                withData(
+                    nameFn = { it.first },
+                    "toKoreanKeyWords" to promptGenerator.toKoreanKeyWords("test"),
+                    "toKoreanHighlightText" to promptGenerator.toKoreanHighlightText("test"),
+                    "toGroupHeadlineOnlyPrompt" to promptGenerator.toGroupHeadlineOnlyPrompt(listOf("test")),
+                    "toGroupHighlightPrompt" to promptGenerator.toGroupHighlightPrompt("test"),
+                ) { (_, prompt) ->
+                    prompt should beAValidPrompt()
+                }
+            }
+        }
+    })

--- a/domain/generator/src/test/kotlin/com/few/generator/domain/CategoryTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/domain/CategoryTest.kt
@@ -1,0 +1,83 @@
+package com.few.generator.domain
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import web.handler.exception.BadRequestException
+
+class CategoryTest :
+    DescribeSpec({
+
+        describe("Category") {
+
+            describe("기본 속성 검증") {
+                it("각 카테고리는 고유한 비트 플래그 코드와 제목을 가진다") {
+                    Category.TECHNOLOGY.code shouldBe 2
+                    Category.TECHNOLOGY.title shouldBe "기술"
+
+                    Category.LIFE.code shouldBe 4
+                    Category.LIFE.title shouldBe "생활"
+
+                    // 비트 연산으로 조합 및 확인 가능
+                    val combined = Category.TECHNOLOGY.code or Category.LIFE.code
+                    ((combined and Category.TECHNOLOGY.code) != 0) shouldBe true
+                    ((combined and Category.POLITICS.code) != 0) shouldBe false
+                }
+            }
+
+            describe("from(code) 메서드") {
+                withData(
+                    nameFn = { "code ${it.first} -> ${it.second}" },
+                    2 to Category.TECHNOLOGY,
+                    4 to Category.LIFE,
+                    8 to Category.POLITICS,
+                    16 to Category.ECONOMY,
+                    32 to Category.SOCIETY,
+                    0 to Category.ETC,
+                ) { (code, expected) ->
+                    Category.from(code) shouldBe expected
+                }
+
+                it("유효하지 않은 코드로 예외를 발생시킨다") {
+                    val exception =
+                        shouldThrow<BadRequestException> {
+                            Category.from(999)
+                        }
+                    exception.message shouldBe "Invalid Category code: 999"
+                }
+            }
+
+            describe("from(title) 메서드") {
+                withData(
+                    nameFn = { "title '${it.first}' -> ${it.second}" },
+                    "기술" to Category.TECHNOLOGY,
+                    "생활" to Category.LIFE,
+                    "정치" to Category.POLITICS,
+                    "경제" to Category.ECONOMY,
+                    "사회" to Category.SOCIETY,
+                    "기타" to Category.ETC,
+                ) { (title, expected) ->
+                    Category.from(title) shouldBe expected
+                }
+
+                it("유효하지 않은 제목으로 예외를 발생시킨다") {
+                    val exception =
+                        shouldThrow<BadRequestException> {
+                            Category.from("존재하지 않는 카테고리")
+                        }
+                    exception.message shouldBe "Invalid Category title: 존재하지 않는 카테고리"
+                }
+            }
+
+            describe("groupGenEntries 메서드") {
+                it("ETC 카테고리를 제외한 모든 카테고리를 반환한다") {
+                    val groupGenCategories = Category.groupGenEntries()
+                    val expected = Category.entries.filter { it != Category.ETC }
+
+                    groupGenCategories shouldContainExactlyInAnyOrder expected
+                }
+            }
+        }
+    })

--- a/domain/generator/src/test/kotlin/com/few/generator/domain/MediaTypeTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/domain/MediaTypeTest.kt
@@ -1,0 +1,94 @@
+package com.few.generator.domain
+
+import com.few.generator.fixture.TestConstants
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import web.handler.exception.BadRequestException
+
+class MediaTypeTest :
+    DescribeSpec({
+
+        describe("MediaType") {
+
+            describe(TestConstants.MEDIATYPE_TEST_BASIC_PROPERTIES_VERIFICATION) {
+                it(TestConstants.MEDIATYPE_TEST_UNIQUE_CODE_TITLE_KEYWORDS) {
+                    MediaType.CHOSUN.code shouldBe 1
+                    MediaType.CHOSUN.title shouldBe TestConstants.MEDIATYPE_TITLE_CHOSUN
+                    MediaType.CHOSUN.keywords shouldContain TestConstants.MEDIATYPE_KEYWORD_CHOSUN
+
+                    MediaType.KHAN.code shouldBe 2
+                    MediaType.KHAN.title shouldBe TestConstants.MEDIATYPE_TITLE_KHAN
+                    MediaType.KHAN.keywords shouldContain TestConstants.MEDIATYPE_KEYWORD_KHAN
+                }
+
+                it(TestConstants.MEDIATYPE_TEST_ALL_MEDIA_TYPES_HAVE_KEYWORDS) {
+                    MediaType.entries.forEach { mediaType ->
+                        if (mediaType != MediaType.ETC) {
+                            mediaType.keywords.shouldNotBeEmpty()
+                        }
+                    }
+                }
+            }
+
+            describe(TestConstants.MEDIATYPE_TEST_FROM_CODE_METHOD) {
+                withData(
+                    nameFn = { "code ${it.first} -> ${it.second}" },
+                    1 to MediaType.CHOSUN,
+                    2 to MediaType.KHAN,
+                    3 to MediaType.SBS,
+                    0 to MediaType.ETC,
+                ) { (code, expected) ->
+                    MediaType.from(code) shouldBe expected
+                }
+
+                it(TestConstants.MEDIATYPE_TEST_INVALID_CODE_THROWS_EXCEPTION) {
+                    val exception =
+                        shouldThrow<BadRequestException> {
+                            MediaType.from(999)
+                        }
+                    exception.message shouldBe String.format(TestConstants.MEDIATYPE_TEST_INVALID_CODE_MESSAGE_FORMAT, 999)
+                }
+            }
+
+            describe(TestConstants.MEDIATYPE_TEST_FROM_TITLE_METHOD) {
+                withData(
+                    nameFn = { "title '${it.first}' -> ${it.second}" },
+                    TestConstants.MEDIATYPE_TITLE_CHOSUN to MediaType.CHOSUN,
+                    TestConstants.MEDIATYPE_TITLE_KHAN to MediaType.KHAN,
+                    TestConstants.MEDIATYPE_TITLE_SBS to MediaType.SBS,
+                    TestConstants.MEDIATYPE_TITLE_ETC to MediaType.ETC,
+                ) { (title, expected) ->
+                    MediaType.from(title) shouldBe expected
+                }
+
+                it(TestConstants.MEDIATYPE_TEST_INVALID_TITLE_THROWS_EXCEPTION) {
+                    val exception =
+                        shouldThrow<BadRequestException> {
+                            MediaType.from(TestConstants.MEDIATYPE_INVALID_TITLE)
+                        }
+                    exception.message shouldBe
+                        String.format(TestConstants.MEDIATYPE_TEST_INVALID_NAME_MESSAGE_FORMAT, TestConstants.MEDIATYPE_INVALID_TITLE)
+                }
+            }
+
+            describe(TestConstants.MEDIATYPE_TEST_FIND_METHOD) {
+                withData(
+                    nameFn = { "input '${it.first.take(30)}...' -> ${it.second}" },
+                    TestConstants.MEDIATYPE_URL_CHOSUN to MediaType.CHOSUN,
+                    TestConstants.MEDIATYPE_URL_KHAN to MediaType.KHAN,
+                    TestConstants.MEDIATYPE_URL_SBS to MediaType.SBS,
+                    TestConstants.MEDIATYPE_URL_YONHAPNEWS_TV to MediaType.YONHAPNEWS_TV,
+                    TestConstants.MEDIATYPE_KEYWORD_CHOSUN.uppercase() to MediaType.CHOSUN, // 대소문자
+                    TestConstants.MEDIATYPE_PARTIAL_MATCH_CHOSUN to MediaType.CHOSUN, // 부분 문자열
+                    TestConstants.MEDIATYPE_UNKNOWN_NEWS_SITE to MediaType.ETC, // 매칭 실패
+                    TestConstants.MEDIATYPE_EMPTY_STRING to MediaType.ETC, // 빈 문자열
+                ) { (input, expected) ->
+                    MediaType.find(input) shouldBe expected
+                }
+            }
+        }
+    })

--- a/domain/generator/src/test/kotlin/com/few/generator/domain/vo/GenDetailTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/domain/vo/GenDetailTest.kt
@@ -1,0 +1,63 @@
+package com.few.generator.domain.vo
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class GenDetailTest :
+    DescribeSpec({
+
+        describe("GenDetail") {
+
+            it("값에 의한 동등성 비교") {
+                val genDetail1 =
+                    GenDetail(
+                        headline = "같은 헤드라인",
+                        keywords = "같은 키워드",
+                    )
+
+                val genDetail2 =
+                    GenDetail(
+                        headline = "같은 헤드라인",
+                        keywords = "같은 키워드",
+                    )
+
+                val genDetail3 =
+                    GenDetail(
+                        headline = "다른 헤드라인",
+                        keywords = "다른 키워드",
+                    )
+
+                genDetail1 shouldBe genDetail2
+                genDetail1.hashCode() shouldBe genDetail2.hashCode()
+                genDetail1 shouldNotBe genDetail3
+            }
+
+            it("copy 메서드") {
+                val original =
+                    GenDetail(
+                        headline = "원본 헤드라인",
+                        keywords = "원본 키워드",
+                    )
+
+                val copied = original.copy(headline = "변경된 헤드라인")
+
+                copied.headline shouldBe "변경된 헤드라인"
+                copied.keywords shouldBe "원본 키워드"
+                copied shouldNotBe original
+            }
+
+            it("구조 분해 선언") {
+                val genDetail =
+                    GenDetail(
+                        headline = "구조 분해 헤드라인",
+                        keywords = "구조 분해 키워드",
+                    )
+
+                val (headline, keywords) = genDetail
+
+                headline shouldBe "구조 분해 헤드라인"
+                keywords shouldBe "구조 분해 키워드"
+            }
+        }
+    })

--- a/domain/generator/src/test/kotlin/com/few/generator/service/GenServiceTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/service/GenServiceTest.kt
@@ -1,0 +1,99 @@
+package com.few.generator.service
+
+import com.few.generator.core.gpt.ChatGpt
+import com.few.generator.core.gpt.prompt.Prompt
+import com.few.generator.core.gpt.prompt.PromptGenerator
+import com.few.generator.core.gpt.prompt.schema.Headline
+import com.few.generator.core.gpt.prompt.schema.HighlightText
+import com.few.generator.core.gpt.prompt.schema.Summary
+import com.few.generator.domain.Category
+import com.few.generator.domain.Gen
+import com.few.generator.fixture.RandomDataGenerator
+import com.few.generator.repository.GenRepository
+import com.google.gson.Gson
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class GenServiceTest :
+    DescribeSpec({
+
+        val promptGenerator = mockk<PromptGenerator>()
+        val chatGpt = mockk<ChatGpt>()
+        val genRepository = mockk<GenRepository>()
+        val gson = Gson()
+        val genService = GenService(promptGenerator, chatGpt, genRepository, gson)
+
+        describe("GenService") {
+
+            describe("create") {
+                it("RawContents와 ProvisioningContents로 Gen을 생성한다") {
+                    val rawContents = RandomDataGenerator.randomRawContents()
+                    val provisioningContents = RandomDataGenerator.randomProvisioningContents()
+
+                    val headlinePrompt = mockk<Prompt>()
+                    val summaryPrompt = mockk<Prompt>()
+                    val highlightPrompt = mockk<Prompt>()
+
+                    val mockHeadline = Headline("생성된 헤드라인").apply { completionId = "completion-1" }
+                    val mockSummary = Summary("생성된 요약").apply { completionId = "completion-2" }
+                    val mockHighlightText = HighlightText("생성된 하이라이트").apply { completionId = "completion-3" }
+
+                    val expectedGen =
+                        Gen(
+                            id = 1L,
+                            provisioningContentsId = provisioningContents.id!!,
+                            completionIds =
+                                mutableListOf(
+                                    mockHeadline.completionId!!,
+                                    mockSummary.completionId!!,
+                                    mockHighlightText.completionId!!,
+                                ),
+                            headline = mockHeadline.headline,
+                            summary = mockSummary.summary,
+                            highlightTexts = gson.toJson(listOf(mockHighlightText.highlightText)),
+                            category = Category.from(provisioningContents.category).code,
+                        )
+
+                    every { promptGenerator.toHeadlineShort(any(), any(), any()) } returns headlinePrompt
+                    every { promptGenerator.toSummaryShort(any(), any(), any(), any()) } returns summaryPrompt
+                    every { promptGenerator.toKoreanHighlightText(any()) } returns highlightPrompt
+
+                    every { chatGpt.ask(headlinePrompt) } returns mockHeadline
+                    every { chatGpt.ask(summaryPrompt) } returns mockSummary
+                    every { chatGpt.ask(highlightPrompt) } returns mockHighlightText
+
+                    every { genRepository.save(any<Gen>()) } returns expectedGen
+
+                    val result = genService.create(rawContents, provisioningContents)
+
+                    result.headline shouldBe mockHeadline.headline
+                    result.summary shouldBe mockSummary.summary
+                    result.category shouldBe Category.from(provisioningContents.category).code
+
+                    verify {
+                        promptGenerator.toHeadlineShort(
+                            rawContents.title,
+                            rawContents.description,
+                            provisioningContents.coreTextsJson,
+                        )
+                    }
+                    verify {
+                        promptGenerator.toSummaryShort(
+                            mockHeadline.headline,
+                            rawContents.title,
+                            rawContents.description,
+                            provisioningContents.coreTextsJson,
+                        )
+                    }
+                    verify { promptGenerator.toKoreanHighlightText(mockSummary.summary) }
+                    verify { chatGpt.ask(headlinePrompt) }
+                    verify { chatGpt.ask(summaryPrompt) }
+                    verify { chatGpt.ask(highlightPrompt) }
+                    verify { genRepository.save(any<Gen>()) }
+                }
+            }
+        }
+    })

--- a/domain/generator/src/test/kotlin/com/few/generator/service/KeyWordsServiceTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/service/KeyWordsServiceTest.kt
@@ -1,0 +1,124 @@
+package com.few.generator.service
+
+import com.few.generator.core.gpt.ChatGpt
+import com.few.generator.core.gpt.prompt.Prompt
+import com.few.generator.core.gpt.prompt.PromptGenerator
+import com.few.generator.core.gpt.prompt.schema.GptResponse
+import com.few.generator.fixture.extensions.asString
+import com.few.generator.fixture.gpt.KeywordsFixture
+import com.few.generator.fixture.gpt.KeywordsTestData
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.TimeUnit
+
+class KeyWordsServiceTest :
+    DescribeSpec({
+
+        val promptGenerator = mockk<PromptGenerator>()
+        val chatGpt = mockk<ChatGpt>()
+        val keyWordsService = KeyWordsService(promptGenerator, chatGpt)
+
+        fun setupMocks(
+            coreTexts: String,
+            response: GptResponse,
+        ) {
+            val prompt = mockk<Prompt>()
+            every { promptGenerator.toKoreanKeyWords(coreTexts) } returns prompt
+            every { chatGpt.ask(prompt) } returns response
+        }
+
+        fun setupErrorMocks(
+            coreTexts: String,
+            exception: Exception,
+        ) {
+            val prompt = mockk<Prompt>()
+            every { promptGenerator.toKoreanKeyWords(coreTexts) } returns prompt
+            every { chatGpt.ask(prompt) } throws exception
+        }
+
+        describe("generateKeyWords") {
+            it("핵심 텍스트에서 키워드를 생성한다") {
+                val coreTexts = KeywordsTestData.DEFAULT_CORE_TEXT
+                val keywords = KeywordsFixture.default().sample()
+                setupMocks(coreTexts, keywords)
+
+                val result = keyWordsService.generateKeyWords(coreTexts)
+
+                result shouldBe keywords.asString()
+                verify(exactly = 1) { promptGenerator.toKoreanKeyWords(coreTexts) }
+                verify(exactly = 1) { chatGpt.ask(any()) }
+            }
+
+            it("빈 문자열에 대해서도 키워드를 생성한다") {
+                val coreTexts = KeywordsTestData.EMPTY_TEXT
+                val keywords = KeywordsFixture.empty().sample()
+                setupMocks(coreTexts, keywords)
+
+                val result = keyWordsService.generateKeyWords(coreTexts)
+
+                result shouldBe keywords.asString()
+            }
+
+            it("GPT 응답이 Keywords 타입이 아니면 예외를 발생시킨다") {
+                val coreTexts = KeywordsTestData.ERROR_TEXT
+                setupMocks(coreTexts, mockk<GptResponse>()) // Not a Keywords instance
+
+                shouldThrow<IllegalStateException> {
+                    keyWordsService.generateKeyWords(coreTexts)
+                }
+            }
+        }
+
+        describe("generateKeyWordsAsync") {
+            it("비동기적으로 키워드를 생성한다") {
+                val coreTexts = KeywordsTestData.ASYNC_TEXT
+                val keywords = KeywordsFixture.async().sample()
+                setupMocks(coreTexts, keywords)
+
+                val future = keyWordsService.generateKeyWordsAsync(coreTexts)
+                val result = future.get(5, TimeUnit.SECONDS)
+
+                result shouldBe keywords.asString()
+            }
+
+            it("비동기 처리 중 오류 발생 시 실패 메시지를 반환한다") {
+                val coreTexts = KeywordsTestData.ASYNC_ERROR_TEXT
+                setupErrorMocks(coreTexts, RuntimeException("API 오류"))
+
+                val future = keyWordsService.generateKeyWordsAsync(coreTexts)
+                val result = future.get(5, TimeUnit.SECONDS)
+
+                result shouldBe KeywordsTestData.FAILURE_MESSAGE
+            }
+        }
+
+        describe("generateKeyWordsWithCoroutine") {
+            it("코루틴으로 키워드를 생성한다") {
+                runBlocking {
+                    val coreTexts = KeywordsTestData.COROUTINE_TEXT
+                    val keywords = KeywordsFixture.coroutine().sample()
+                    setupMocks(coreTexts, keywords)
+
+                    val result = keyWordsService.generateKeyWordsWithCoroutine(coreTexts)
+
+                    result shouldBe keywords.asString()
+                }
+            }
+
+            it("코루틴 처리 중 오류 발생 시 실패 메시지를 반환한다") {
+                runBlocking {
+                    val coreTexts = KeywordsTestData.COROUTINE_ERROR_TEXT
+                    setupErrorMocks(coreTexts, RuntimeException("API 오류"))
+
+                    val result = keyWordsService.generateKeyWordsWithCoroutine(coreTexts)
+
+                    result shouldBe KeywordsTestData.FAILURE_MESSAGE
+                }
+            }
+        }
+    })

--- a/domain/generator/src/test/kotlin/com/few/generator/support/utils/CompressUtilsTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/support/utils/CompressUtilsTest.kt
@@ -1,0 +1,83 @@
+package com.few.generator.support.utils
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+import java.util.*
+import java.util.zip.ZipException
+
+class CompressUtilsTest :
+    DescribeSpec({
+
+        describe("CompressUtils") {
+
+            describe("압축 및 해제") {
+                withData(
+                    nameFn = { "입력: ${it.take(20)}..." },
+                    "Hello World! This is a test string for compression.",
+                    "안녕하세요! 이것은 한글 압축 테스트입니다. 가나다라마바사아자차카타파하",
+                    "Hello! @#$%^&*()_+-=[]{}|;':\",.<>?",
+                    """{"name": "테스트", "value": 123, "array": [1, 2, 3]}""",
+                    "A".repeat(1000),
+                ) { original ->
+                    val compressed = CompressUtils.compress(original)
+                    val decompressed = CompressUtils.decompress(compressed)
+
+                    decompressed shouldBe original
+                    compressed shouldNotBe original
+                    compressed.shouldNotBeEmpty()
+                }
+
+                it("빈 문자열을 압축하고 해제할 수 있다") {
+                    val original = ""
+
+                    val compressed = CompressUtils.compress(original)
+                    val decompressed = CompressUtils.decompress(compressed)
+
+                    decompressed shouldBe original
+                }
+            }
+
+            describe("오류 처리") {
+                it("잘못된 Base64 문자열로 해제 시도 시 예외가 발생한다") {
+                    val invalidBase64 = "This is not a valid Base64 string!"
+
+                    shouldThrow<IllegalArgumentException> {
+                        CompressUtils.decompress(invalidBase64)
+                    }
+                }
+
+                it("잘못된 GZIP 데이터로 해제 시도 시 예외가 발생한다") {
+                    val invalidGzip = Base64.getEncoder().encodeToString("invalid gzip data".toByteArray())
+
+                    shouldThrow<ZipException> {
+                        CompressUtils.decompress(invalidGzip)
+                    }
+                }
+            }
+
+            describe("압축 효율성") {
+                it("반복되는 패턴이 많은 문자열은 압축 효율이 좋다") {
+                    val original = "AAAAAAAAAA".repeat(100)
+
+                    val compressed = CompressUtils.compress(original)
+
+                    compressed.length shouldBeLessThan (original.length / 2)
+                }
+
+                it("압축된 문자열은 유효한 Base64 형태이다") {
+                    val original = "Test string for Base64 validation"
+
+                    val compressed = CompressUtils.compress(original)
+
+                    // Base64 디코딩이 성공하는지 확인하여 유효성 검증
+                    val decoded = Base64.getDecoder().decode(compressed)
+                    decoded.isNotEmpty() shouldBe true
+                }
+            }
+        }
+    })

--- a/domain/generator/src/test/resources/application-generator-test.yaml
+++ b/domain/generator/src/test/resources/application-generator-test.yaml
@@ -1,0 +1,61 @@
+spring:
+  cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            connectTimeout: 5000
+            readTimeout: 30000
+            loggerLevel: basic
+          openai:
+            url: http://localhost:8080/mock-openai
+            errorDecoder: com.few.generator.config.feign.OpenAiErrorDecoder
+            defaultRequestHeaders:
+              Authorization: "Bearer test-token"
+              Content-Type: "application/json"
+            requestInterceptors:
+              - com.few.generator.config.feign.OpenAiRequestInterceptor
+            encoder: com.few.generator.config.feign.OpenAiEncoder
+            decoder: com.few.generator.config.feign.OpenAiDecoder
+  generator:
+    datasource:
+      url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+      username: sa
+      password: 
+      driver-class-name: org.h2.Driver
+    jpa:
+      hibernate:
+        ddl-auto: create-drop
+      properties:
+        hibernate:
+          format_sql: true
+          show_sql: true
+
+jsoup:
+  timeout: 5000
+  userAgent: "Test Agent"
+  followRedirects: true
+  ignoreHttpErrors: true
+  ignoreContentType: true
+
+scheduling:
+  cron:
+    generator: "0 0 4 * * *"
+    group: "0 0 5 * * *"
+
+urls:
+  webhook:
+    discord: "http://localhost:8080/webhook/discord/test"
+
+generator:
+  scraping:
+    maxRetries: 3
+    defaultRetryAfter: 1
+  contents:
+    countByCategory: 1
+    pageSize: 10
+  grouping:
+    targetPercentage: 30
+    minGroupSize: 2
+    maxGroupSize: 5
+    similarityThreshold: 0.5

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/FixtureMonkeyConfig.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/FixtureMonkeyConfig.kt
@@ -1,0 +1,32 @@
+package com.few.generator.fixture
+
+import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
+import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
+import com.navercorp.fixturemonkey.kotlin.giveMeOne
+
+/**
+ * FixtureMonkey 설정 및 공통 픽스쳐 생성기
+ */
+object FixtureMonkeyConfig {
+    val fixtureMonkey: FixtureMonkey =
+        FixtureMonkey
+            .builder()
+            .plugin(KotlinPlugin())
+            .build()
+
+    /**
+     * 기본 랜덤 객체 생성
+     */
+    inline fun <reified T> random(): T = fixtureMonkey.giveMeOne()
+
+    /**
+     * 커스텀 설정이 가능한 빌더 반환
+     */
+    inline fun <reified T> builder() = fixtureMonkey.giveMeBuilder<T>()
+
+    /**
+     * 여러 개의 랜덤 객체 생성
+     */
+    inline fun <reified T> randomList(size: Int = 3): List<T> = (1..size).map { fixtureMonkey.giveMeOne<T>() }
+}

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/RandomDataGenerator.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/RandomDataGenerator.kt
@@ -1,0 +1,266 @@
+package com.few.generator.fixture
+
+import com.few.generator.domain.Category
+import com.few.generator.domain.Gen
+import com.few.generator.domain.GroupGen
+import com.few.generator.domain.ProvisioningContents
+import com.few.generator.domain.RawContents
+import com.few.generator.domain.vo.GenDetail
+import java.time.LocalDateTime
+import kotlin.random.Random
+
+object RandomDataGenerator {
+    private val koreanWords =
+        listOf(
+            "기술",
+            "혁신",
+            "발전",
+            "미래",
+            "변화",
+            "성장",
+            "도전",
+            "기회",
+            "성공",
+            "전략",
+            "솔루션",
+            "플랫폼",
+            "시스템",
+            "서비스",
+            "프로젝트",
+            "데이터",
+            "분석",
+            "개발",
+            "경제",
+            "사회",
+            "환경",
+            "문화",
+            "교육",
+            "건강",
+            "안전",
+            "품질",
+            "효율성",
+        )
+
+    private val englishWords =
+        listOf(
+            "technology",
+            "innovation",
+            "development",
+            "future",
+            "change",
+            "growth",
+            "challenge",
+            "opportunity",
+            "success",
+            "strategy",
+            "solution",
+            "platform",
+            "system",
+            "service",
+            "project",
+            "data",
+            "analysis",
+            "development",
+            "economy",
+            "society",
+            "environment",
+            "culture",
+            "education",
+            "health",
+            "safety",
+            "quality",
+            "efficiency",
+        )
+
+    private val headlines =
+        listOf(
+            "AI 기술의 새로운 돌파구",
+            "블록체인 혁신의 미래",
+            "클라우드 컴퓨팅의 진화",
+            "IoT 디바이스의 확산",
+            "5G 네트워크 구축 가속화",
+            "사이버 보안 강화 방안",
+            "빅데이터 분석 기술 발전",
+            "머신러닝 알고리즘 최적화",
+            "자율주행차 기술 진보",
+            "스마트시티 구축 프로젝트",
+            "디지털 트랜스포메이션",
+            "핀테크 서비스 혁신",
+        )
+
+    private val summaries =
+        listOf(
+            "최신 기술 동향에 대한 분석과 전망을 제시합니다.",
+            "새로운 비즈니스 모델의 등장과 시장 변화를 다룹니다.",
+            "디지털 혁신이 가져올 사회적 영향을 살펴봅니다.",
+            "기술 발전이 우리 생활에 미치는 긍정적 효과를 설명합니다.",
+            "산업 전반에 걸친 혁신 사례를 상세히 소개합니다.",
+            "미래 기술 트렌드와 준비해야 할 과제를 제시합니다.",
+        )
+
+    private val highlightTexts =
+        listOf(
+            "혁신적인 기술 발전",
+            "사용자 경험 향상",
+            "비용 효율성 개선",
+            "보안 수준 강화",
+            "성능 최적화",
+            "확장성 증대",
+            "접근성 개선",
+            "지속가능성 확보",
+            "경쟁력 강화",
+            "품질 향상",
+        )
+
+    private val keywords =
+        listOf(
+            "인공지능, 머신러닝, 딥러닝",
+            "블록체인, 암호화폐, 스마트컨트랙트",
+            "클라우드, 서버리스, 마이크로서비스",
+            "IoT, 센서, 스마트디바이스",
+            "5G, 네트워크, 통신",
+            "보안, 암호화, 인증",
+            "빅데이터, 분석, 시각화",
+            "자동화, 최적화, 효율성",
+            "모바일, 앱, 플랫폼",
+            "디지털, 트랜스포메이션, 혁신",
+        )
+
+    fun randomKoreanWord(): String = koreanWords.random()
+
+    fun randomEnglishWord(): String = englishWords.random()
+
+    fun randomHeadline(): String = headlines.random() + " ${Random.nextInt(1000)}"
+
+    fun randomSummary(): String = summaries.random() + " (${Random.nextInt(100)})"
+
+    fun randomHighlightText(): String = highlightTexts.random() + " ${Random.nextInt(100)}"
+
+    fun randomKeywords(): String = keywords.random()
+
+    fun randomCategory(): Category = Category.entries.random()
+
+    fun randomMediaType(): Int = Random.nextInt(1, 4)
+
+    fun randomId(): Long = Random.nextLong(1, 10000)
+
+    fun randomUrl(): String = "https://example${Random.nextInt(1000)}.com/article/${Random.nextInt(10000)}"
+
+    fun randomDateTime(): LocalDateTime = LocalDateTime.now().minusDays(Random.nextLong(0, 30))
+
+    fun randomCompletionId(): String = "completion-${Random.nextInt(100000)}"
+
+    fun randomGen(
+        id: Long = randomId(),
+        provisioningContentsId: Long = randomId(),
+        headline: String = randomHeadline(),
+        summary: String = randomSummary(),
+        category: Category = randomCategory(),
+        highlightTexts: List<String> = listOf(randomHighlightText(), randomHighlightText()),
+    ): Gen =
+        Gen(
+            id = id,
+            provisioningContentsId = provisioningContentsId,
+            completionIds = mutableListOf(randomCompletionId(), randomCompletionId(), randomCompletionId()),
+            headline = headline,
+            summary = summary,
+            highlightTexts = """["${highlightTexts.joinToString("\", \"")}"]""",
+            category = category.code,
+        )
+
+    fun randomRawContents(
+        id: Long = randomId(),
+        title: String = randomHeadline(),
+        description: String = randomSummary(),
+        category: Category = randomCategory(),
+    ): RawContents =
+        RawContents(
+            id = id,
+            url = randomUrl(),
+            title = title,
+            description = description,
+            rawTexts = randomSummary(),
+            category = category.code,
+            mediaType = randomMediaType(),
+        )
+
+    fun randomProvisioningContents(
+        id: Long = randomId(),
+        rawContentsId: Long = randomId(),
+        coreTextsJson: String? = randomSummary(),
+        category: Category = randomCategory(),
+    ): ProvisioningContents =
+        ProvisioningContents(
+            id = id,
+            rawContentsId = rawContentsId,
+            coreTextsJson = coreTextsJson ?: randomSummary(),
+            category = category.code,
+        )
+
+    fun randomGroupGen(
+        id: Long = randomId(),
+        headline: String = randomHeadline(),
+        summary: String = randomSummary(),
+        category: Category = randomCategory(),
+        selectedGroupIds: List<Int> = listOf(0, 1, 2, 3, 4).shuffled().take(Random.nextInt(2, 5)),
+    ): GroupGen =
+        GroupGen(
+            id = id,
+            category = category.code,
+            selectedGroupIds = selectedGroupIds.toString(),
+            headline = headline,
+            summary = summary,
+        )
+
+    fun randomGenDetail(
+        headline: String = randomHeadline(),
+        keywords: String = randomKeywords(),
+    ): GenDetail =
+        GenDetail(
+            headline = headline,
+            keywords = keywords,
+        )
+
+    fun randomString(length: Int = 10): String {
+        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        return (1..length)
+            .map { chars.random() }
+            .joinToString("")
+    }
+
+    fun randomEmail(): String = "${randomString(8)}@example.com"
+
+    fun randomPhoneNumber(): String = "010-${Random.nextInt(1000, 9999)}-${Random.nextInt(1000, 9999)}"
+
+    fun randomBoolean(): Boolean = Random.nextBoolean()
+
+    fun randomDouble(
+        min: Double = 0.0,
+        max: Double = 100.0,
+    ): Double = Random.nextDouble(min, max)
+
+    fun randomInt(
+        min: Int = 0,
+        max: Int = 100,
+    ): Int = Random.nextInt(min, max)
+
+    fun <T> randomListOf(
+        generator: () -> T,
+        size: Int = Random.nextInt(1, 6),
+    ): List<T> = (1..size).map { generator() }
+
+    fun randomNullableString(probability: Double = 0.5): String? = if (Random.nextDouble() < probability) randomString() else null
+
+    fun randomException(): Exception {
+        val messages =
+            listOf(
+                "Network timeout",
+                "Database connection failed",
+                "Invalid input parameter",
+                "Permission denied",
+                "Resource not found",
+                "Service unavailable",
+            )
+        return RuntimeException(messages.random())
+    }
+}

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/TestConstants.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/TestConstants.kt
@@ -1,0 +1,32 @@
+package com.few.generator.fixture
+
+/**
+ * 테스트에서 사용하는 상수들을 관리하는 객체
+ */
+object TestConstants {
+    // MediaTypeTest 상수들
+    const val MEDIATYPE_TEST_BASIC_PROPERTIES_VERIFICATION = "기본 속성 검증"
+    const val MEDIATYPE_TEST_UNIQUE_CODE_TITLE_KEYWORDS = "각 미디어 타입은 고유한 코드와 제목, 키워드를 가진다"
+    const val MEDIATYPE_TEST_ALL_MEDIA_TYPES_HAVE_KEYWORDS = "모든 미디어 타입(ETC 제외)은 최소 하나의 키워드를 가진다"
+    const val MEDIATYPE_TEST_FROM_CODE_METHOD = "from(code) 메서드"
+    const val MEDIATYPE_TEST_INVALID_CODE_THROWS_EXCEPTION = "존재하지 않는 코드는 올바른 메시지와 함께 예외를 던진다"
+    const val MEDIATYPE_TEST_FROM_TITLE_METHOD = "from(title) 메서드"
+    const val MEDIATYPE_TEST_INVALID_TITLE_THROWS_EXCEPTION = "존재하지 않는 제목은 올바른 메시지와 함께 예외를 던진다"
+    const val MEDIATYPE_TEST_FIND_METHOD = "find(input) 메서드"
+    const val MEDIATYPE_TEST_INVALID_CODE_MESSAGE_FORMAT = "Invalid MediaType code: %d"
+    const val MEDIATYPE_TEST_INVALID_NAME_MESSAGE_FORMAT = "Invalid MediaType name: %s"
+    const val MEDIATYPE_KEYWORD_CHOSUN = "chosun"
+    const val MEDIATYPE_KEYWORD_KHAN = "khan"
+    const val MEDIATYPE_TITLE_CHOSUN = "조선일보"
+    const val MEDIATYPE_TITLE_KHAN = "경향신문"
+    const val MEDIATYPE_TITLE_SBS = "SBS"
+    const val MEDIATYPE_TITLE_ETC = "ETC"
+    const val MEDIATYPE_URL_CHOSUN = "https://www.chosun.com/article"
+    const val MEDIATYPE_URL_KHAN = "https://khan.co.kr/news"
+    const val MEDIATYPE_URL_SBS = "https://news.sbs.co.kr/news"
+    const val MEDIATYPE_URL_YONHAPNEWS_TV = "https://www.yonhapnews.co.kr/bulletin"
+    const val MEDIATYPE_UNKNOWN_NEWS_SITE = "https://unknown-news-site.com/article"
+    const val MEDIATYPE_INVALID_TITLE = "존재하지않는신문"
+    const val MEDIATYPE_PARTIAL_MATCH_CHOSUN = "이 기사는 조선일보에서 chosun.com을 통해 제공됩니다"
+    const val MEDIATYPE_EMPTY_STRING = ""
+}

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/extensions/KeywordsExtensions.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/extensions/KeywordsExtensions.kt
@@ -1,0 +1,8 @@
+package com.few.generator.fixture.extensions
+
+import com.few.generator.core.gpt.prompt.schema.Keywords
+
+/**
+ * Keywords 관련 확장 함수들
+ */
+fun Keywords.asString(): String = keywords.joinToString(", ")

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/gpt/KeywordsFixture.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/gpt/KeywordsFixture.kt
@@ -1,0 +1,57 @@
+package com.few.generator.fixture.gpt
+
+import com.few.generator.core.gpt.prompt.schema.Keywords
+import com.few.generator.fixture.FixtureMonkeyConfig.builder
+import com.navercorp.fixturemonkey.kotlin.setExp
+
+/**
+ * Keywords를 위한 FixtureMonkey 기반 픽스쳐
+ */
+object KeywordsFixture {
+    /**
+     * 기본 랜덤 키워드
+     */
+    fun random(): Keywords =
+        com.few.generator.fixture.FixtureMonkeyConfig
+            .random()
+
+    /**
+     * 기본 테스트 키워드 빌더
+     */
+    fun default() =
+        builder<Keywords>()
+            .setExp(Keywords::keywords, listOf("인공지능", "기술", "자동화", "발전"))
+
+    /**
+     * 빈 키워드 빌더
+     */
+    fun empty() =
+        builder<Keywords>()
+            .setExp(Keywords::keywords, emptyList<String>())
+
+    /**
+     * 비동기 테스트용 키워드 빌더
+     */
+    fun async() =
+        builder<Keywords>()
+            .setExp(Keywords::keywords, listOf("비동기", "테스트", "핵심텍스트"))
+
+    /**
+     * 코루틴 테스트용 키워드 빌더
+     */
+    fun coroutine() =
+        builder<Keywords>()
+            .setExp(Keywords::keywords, listOf("코루틴", "테스트", "핵심텍스트"))
+
+    /**
+     * 커스텀 키워드 리스트로 빌더 생성
+     */
+    fun withKeywords(keywords: List<String>) =
+        builder<Keywords>()
+            .setExp(Keywords::keywords, keywords)
+
+    /**
+     * 단일 키워드 빌더
+     */
+    fun single(keyword: String) = withKeywords(listOf(keyword))
+}

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/gpt/KeywordsTestData.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/gpt/KeywordsTestData.kt
@@ -1,0 +1,46 @@
+package com.few.generator.fixture.gpt
+
+/**
+ * Keywords 테스트에서 사용하는 테스트 데이터 상수들
+ */
+object KeywordsTestData {
+    /**
+     * 기본 키워드 생성 테스트를 위한 핵심 텍스트
+     */
+    const val DEFAULT_CORE_TEXT = "인공지능 기술이 발전하면서 자동화가 가속화되고 있다"
+
+    /**
+     * 빈 문자열 입력 테스트를 위한 핵심 텍스트
+     */
+    const val EMPTY_TEXT = ""
+
+    /**
+     * ChatGPT 응답이 Keywords 타입이 아닐 때 예외 발생 테스트를 위한 핵심 텍스트
+     */
+    const val ERROR_TEXT = "오류 테스트 텍스트"
+
+    /**
+     * 비동기 키워드 생성 테스트를 위한 핵심 텍스트
+     */
+    const val ASYNC_TEXT = "비동기 테스트를 위한 핵심 텍스트"
+
+    /**
+     * 코루틴 키워드 생성 테스트를 위한 핵심 텍스트
+     */
+    const val COROUTINE_TEXT = "코루틴 테스트를 위한 핵심 텍스트"
+
+    /**
+     * 비동기 처리 중 예외 발생 테스트를 위한 핵심 텍스트
+     */
+    const val ASYNC_ERROR_TEXT = "비동기 오류 테스트"
+
+    /**
+     * 코루틴 처리 중 예외 발생 테스트를 위한 핵심 텍스트
+     */
+    const val COROUTINE_ERROR_TEXT = "코루틴 오류 테스트"
+
+    /**
+     * 키워드 추출 실패 시 반환되는 메시지
+     */
+    const val FAILURE_MESSAGE = "키워드 추출 실패"
+}

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/BrowseContentsFixture.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/BrowseContentsFixture.kt
@@ -1,0 +1,50 @@
+package com.few.generator.fixture.usecase
+
+import com.few.generator.fixture.FixtureMonkeyConfig.builder
+import com.few.generator.usecase.out.BrowseContentsUsecaseOuts
+import com.few.generator.usecase.out.ContentsUsecaseOut
+import com.navercorp.fixturemonkey.kotlin.setExp
+
+/**
+ * BrowseContentsUsecaseOuts를 위한 FixtureMonkey 기반 픽스쳐
+ */
+object BrowseContentsFixture {
+    /**
+     * 기본 랜덤 데이터로 생성
+     */
+    fun random(): BrowseContentsUsecaseOuts =
+        com.few.generator.fixture.FixtureMonkeyConfig
+            .random()
+
+    /**
+     * 기본 테스트 데이터 빌더 (단일 콘텐츠)
+     */
+    fun default() =
+        builder<BrowseContentsUsecaseOuts>()
+            .setExp(BrowseContentsUsecaseOuts::contents, listOf(ContentsFixture.default().sample()))
+            .setExp(BrowseContentsUsecaseOuts::isLast, false)
+
+    /**
+     * 빈 결과 빌더
+     */
+    fun empty() =
+        builder<BrowseContentsUsecaseOuts>()
+            .setExp(BrowseContentsUsecaseOuts::contents, emptyList<ContentsUsecaseOut>())
+            .setExp(BrowseContentsUsecaseOuts::isLast, true)
+
+    /**
+     * 여러 콘텐츠 포함 빌더
+     */
+    fun multiple() =
+        builder<BrowseContentsUsecaseOuts>()
+            .setExp(BrowseContentsUsecaseOuts::contents, ContentsFixture.multipleContents())
+            .setExp(BrowseContentsUsecaseOuts::isLast, false)
+
+    /**
+     * 커스텀 콘텐츠 리스트로 빌더 생성
+     */
+    fun withContents(contents: List<ContentsUsecaseOut>) =
+        builder<BrowseContentsUsecaseOuts>()
+            .setExp(BrowseContentsUsecaseOuts::contents, contents)
+            .setExp(BrowseContentsUsecaseOuts::isLast, false)
+}

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/BrowseDetailFixture.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/BrowseDetailFixture.kt
@@ -1,0 +1,185 @@
+package com.few.generator.fixture.usecase
+
+import com.few.generator.domain.Category
+import com.few.generator.domain.MediaType
+import com.few.generator.fixture.FixtureMonkeyConfig.builder
+import com.few.generator.usecase.out.BrowseContentsUsecaseOut
+import com.few.generator.usecase.out.BrowseGenUsecaseOut
+import com.few.generator.usecase.out.BrowseProvisioningContentsUsecaseOut
+import com.few.generator.usecase.out.BrowseRawContentsUsecaseOut
+import com.navercorp.fixturemonkey.kotlin.setExp
+import java.time.LocalDateTime
+
+/**
+ * BrowseContentsUsecaseOut (상세 조회용)을 위한 FixtureMonkey 기반 픽스쳐
+ */
+object BrowseDetailFixture {
+    /**
+     * 기본 랜덤 데이터로 생성
+     */
+    fun random(): BrowseContentsUsecaseOut =
+        com.few.generator.fixture.FixtureMonkeyConfig
+            .random()
+
+    /**
+     * 기본 테스트 데이터 빌더
+     */
+    fun default() =
+        builder<BrowseContentsUsecaseOut>()
+            .setExp(BrowseContentsUsecaseOut::rawContents, createDefaultRawContents())
+            .setExp(BrowseContentsUsecaseOut::provisioningContents, createDefaultProvisioningContents())
+            .setExp(BrowseContentsUsecaseOut::gen, createDefaultGen())
+
+    /**
+     * giveMeDefault() - 기존 API 호환성을 위해 유지
+     */
+    fun giveMeDefault() = BrowseDetailBuilder()
+
+    /**
+     * 커스텀 rawContents로 빌더 생성
+     */
+    fun withRawContents(rawContents: BrowseRawContentsUsecaseOut) =
+        builder<BrowseContentsUsecaseOut>()
+            .setExp(BrowseContentsUsecaseOut::rawContents, rawContents)
+            .setExp(BrowseContentsUsecaseOut::provisioningContents, createDefaultProvisioningContents())
+            .setExp(BrowseContentsUsecaseOut::gen, createDefaultGen())
+
+    /**
+     * 커스텀 provisioningContents로 빌더 생성
+     */
+    fun withProvisioningContents(provisioningContents: BrowseProvisioningContentsUsecaseOut) =
+        builder<BrowseContentsUsecaseOut>()
+            .setExp(BrowseContentsUsecaseOut::rawContents, createDefaultRawContents())
+            .setExp(BrowseContentsUsecaseOut::provisioningContents, provisioningContents)
+            .setExp(BrowseContentsUsecaseOut::gen, createDefaultGen())
+
+    /**
+     * 커스텀 gen으로 빌더 생성
+     */
+    fun withGen(gen: BrowseGenUsecaseOut) =
+        builder<BrowseContentsUsecaseOut>()
+            .setExp(BrowseContentsUsecaseOut::rawContents, createDefaultRawContents())
+            .setExp(BrowseContentsUsecaseOut::provisioningContents, createDefaultProvisioningContents())
+            .setExp(BrowseContentsUsecaseOut::gen, gen)
+
+    /**
+     * 기본 RawContents 생성
+     */
+    private fun createDefaultRawContents(): BrowseRawContentsUsecaseOut =
+        builder<BrowseRawContentsUsecaseOut>()
+            .setExp(BrowseRawContentsUsecaseOut::id, 201L)
+            .setExp(BrowseRawContentsUsecaseOut::url, "https://example.com/raw/1")
+            .setExp(BrowseRawContentsUsecaseOut::title, "원본 제목")
+            .setExp(BrowseRawContentsUsecaseOut::description, "원본 설명입니다")
+            .setExp(BrowseRawContentsUsecaseOut::thumbnailImageUrl, "https://example.com/raw-thumb/1.jpg")
+            .setExp(BrowseRawContentsUsecaseOut::rawTexts, "원본 텍스트 내용")
+            .setExp(BrowseRawContentsUsecaseOut::imageUrls, listOf("https://example.com/img1.jpg"))
+            .setExp(BrowseRawContentsUsecaseOut::mediaType, MediaType.CHOSUN)
+            .setExp(BrowseRawContentsUsecaseOut::createdAt, LocalDateTime.now())
+            .sample()
+
+    /**
+     * 기본 ProvisioningContents 생성
+     */
+    private fun createDefaultProvisioningContents(): BrowseProvisioningContentsUsecaseOut =
+        builder<BrowseProvisioningContentsUsecaseOut>()
+            .setExp(BrowseProvisioningContentsUsecaseOut::id, 101L)
+            .setExp(BrowseProvisioningContentsUsecaseOut::rawContentsId, 201L)
+            .setExp(BrowseProvisioningContentsUsecaseOut::completionIds, listOf("completion1"))
+            .setExp(BrowseProvisioningContentsUsecaseOut::bodyTextsJson, listOf("본문 내용"))
+            .setExp(BrowseProvisioningContentsUsecaseOut::coreTextsJson, listOf("핵심 내용"))
+            .setExp(BrowseProvisioningContentsUsecaseOut::createdAt, LocalDateTime.now())
+            .sample()
+
+    /**
+     * 기본 Gen 생성
+     */
+    private fun createDefaultGen(): BrowseGenUsecaseOut =
+        builder<BrowseGenUsecaseOut>()
+            .setExp(BrowseGenUsecaseOut::id, 1L)
+            .setExp(BrowseGenUsecaseOut::provisioningContentsId, 101L)
+            .setExp(BrowseGenUsecaseOut::completionIds, listOf("gen-completion1"))
+            .setExp(BrowseGenUsecaseOut::headline, "생성된 헤드라인")
+            .setExp(BrowseGenUsecaseOut::summary, "생성된 요약입니다")
+            .setExp(BrowseGenUsecaseOut::highlightTexts, listOf("생성된 하이라이트"))
+            .setExp(BrowseGenUsecaseOut::category, Category.TECHNOLOGY)
+            .setExp(BrowseGenUsecaseOut::createdAt, LocalDateTime.now())
+            .sample()
+}
+
+/**
+ * 기존 builder 패턴 호환성을 위한 클래스
+ * 기존 테스트에서 .build() 호출을 지원
+ */
+class BrowseDetailBuilder {
+    private var rawContentsId: Long = 201L
+    private var rawContentsUrl: String = "https://example.com/raw/1"
+    private var rawContentsTitle: String = "원본 제목"
+    private var rawContentsDescription: String = "원본 설명입니다"
+    private var provisioningContentsId: Long = 101L
+    private var genId: Long = 1L
+    private var genHeadline: String = "생성된 헤드라인"
+    private var genSummary: String = "생성된 요약입니다"
+    private var genCategory: Category = Category.TECHNOLOGY
+
+    fun withRawContentsId(id: Long) = apply { this.rawContentsId = id }
+
+    fun withRawContentsUrl(url: String) = apply { this.rawContentsUrl = url }
+
+    fun withRawContentsTitle(title: String) = apply { this.rawContentsTitle = title }
+
+    fun withRawContentsDescription(description: String) = apply { this.rawContentsDescription = description }
+
+    fun withProvisioningContentsId(id: Long) = apply { this.provisioningContentsId = id }
+
+    fun withGenId(id: Long) = apply { this.genId = id }
+
+    fun withGenHeadline(headline: String) = apply { this.genHeadline = headline }
+
+    fun withGenSummary(summary: String) = apply { this.genSummary = summary }
+
+    fun withGenCategory(category: Category) = apply { this.genCategory = category }
+
+    fun build(): BrowseContentsUsecaseOut {
+        val rawContents =
+            builder<BrowseRawContentsUsecaseOut>()
+                .setExp(BrowseRawContentsUsecaseOut::id, rawContentsId)
+                .setExp(BrowseRawContentsUsecaseOut::url, rawContentsUrl)
+                .setExp(BrowseRawContentsUsecaseOut::title, rawContentsTitle)
+                .setExp(BrowseRawContentsUsecaseOut::description, rawContentsDescription)
+                .setExp(BrowseRawContentsUsecaseOut::thumbnailImageUrl, "https://example.com/raw-thumb/1.jpg")
+                .setExp(BrowseRawContentsUsecaseOut::rawTexts, "원본 텍스트 내용")
+                .setExp(BrowseRawContentsUsecaseOut::imageUrls, listOf("https://example.com/img1.jpg"))
+                .setExp(BrowseRawContentsUsecaseOut::mediaType, MediaType.CHOSUN)
+                .setExp(BrowseRawContentsUsecaseOut::createdAt, LocalDateTime.now())
+                .sample()
+
+        val provisioningContents =
+            builder<BrowseProvisioningContentsUsecaseOut>()
+                .setExp(BrowseProvisioningContentsUsecaseOut::id, provisioningContentsId)
+                .setExp(BrowseProvisioningContentsUsecaseOut::rawContentsId, rawContentsId)
+                .setExp(BrowseProvisioningContentsUsecaseOut::completionIds, listOf("completion1"))
+                .setExp(BrowseProvisioningContentsUsecaseOut::bodyTextsJson, listOf("본문 내용"))
+                .setExp(BrowseProvisioningContentsUsecaseOut::coreTextsJson, listOf("핵심 내용"))
+                .setExp(BrowseProvisioningContentsUsecaseOut::createdAt, LocalDateTime.now())
+                .sample()
+
+        val gen =
+            builder<BrowseGenUsecaseOut>()
+                .setExp(BrowseGenUsecaseOut::id, genId)
+                .setExp(BrowseGenUsecaseOut::provisioningContentsId, provisioningContentsId)
+                .setExp(BrowseGenUsecaseOut::completionIds, listOf("gen-completion1"))
+                .setExp(BrowseGenUsecaseOut::headline, genHeadline)
+                .setExp(BrowseGenUsecaseOut::summary, genSummary)
+                .setExp(BrowseGenUsecaseOut::highlightTexts, listOf("생성된 하이라이트"))
+                .setExp(BrowseGenUsecaseOut::category, genCategory)
+                .setExp(BrowseGenUsecaseOut::createdAt, LocalDateTime.now())
+                .sample()
+
+        return builder<BrowseContentsUsecaseOut>()
+            .setExp(BrowseContentsUsecaseOut::rawContents, rawContents)
+            .setExp(BrowseContentsUsecaseOut::provisioningContents, provisioningContents)
+            .setExp(BrowseContentsUsecaseOut::gen, gen)
+            .sample()
+    }
+}

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/BrowseGroupGenResponseFixture.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/BrowseGroupGenResponseFixture.kt
@@ -1,0 +1,55 @@
+package com.few.generator.fixture.usecase
+
+import com.few.generator.controller.response.BrowseGroupGenResponse
+import com.few.generator.fixture.FixtureMonkeyConfig.builder
+import com.navercorp.fixturemonkey.kotlin.setExp
+import java.time.LocalDateTime
+
+/**
+ * BrowseGroupGenResponse를 위한 FixtureMonkey 기반 픽스쳐
+ */
+object BrowseGroupGenResponseFixture {
+    /**
+     * 기본 랜덤 데이터로 생성
+     */
+    fun random(): BrowseGroupGenResponse =
+        com.few.generator.fixture.FixtureMonkeyConfig
+            .random()
+
+    /**
+     * 기본 테스트 데이터 빌더
+     */
+    fun default() =
+        builder<BrowseGroupGenResponse>()
+            .setExp(BrowseGroupGenResponse::id, 1L)
+            .setExp(BrowseGroupGenResponse::category, 2)
+            .setExp(BrowseGroupGenResponse::selectedGroupIds, "[1, 2, 3]")
+            .setExp(BrowseGroupGenResponse::headline, "그룹 헤드라인")
+            .setExp(BrowseGroupGenResponse::summary, "그룹 요약")
+            .setExp(BrowseGroupGenResponse::highlightTexts, listOf("그룹 하이라이트1", "그룹 하이라이트2"))
+            .setExp(BrowseGroupGenResponse::groupSourceHeadlines, GroupSourceHeadlineDataFixture.multipleHeadlines())
+            .setExp(BrowseGroupGenResponse::createdAt, LocalDateTime.now())
+
+    /**
+     * 두 번째 테스트 데이터 빌더
+     */
+    fun second() =
+        builder<BrowseGroupGenResponse>()
+            .setExp(BrowseGroupGenResponse::id, 2L)
+            .setExp(BrowseGroupGenResponse::category, 4)
+            .setExp(BrowseGroupGenResponse::selectedGroupIds, "[4, 5, 6]")
+            .setExp(BrowseGroupGenResponse::headline, "두 번째 그룹 헤드라인")
+            .setExp(BrowseGroupGenResponse::summary, "두 번째 그룹 요약")
+            .setExp(BrowseGroupGenResponse::highlightTexts, listOf("두 번째 하이라이트1", "두 번째 하이라이트2"))
+            .setExp(BrowseGroupGenResponse::groupSourceHeadlines, GroupSourceHeadlineDataFixture.multipleHeadlines())
+            .setExp(BrowseGroupGenResponse::createdAt, LocalDateTime.now())
+
+    /**
+     * 여러 그룹 응답 생성
+     */
+    fun multipleResponses(): List<BrowseGroupGenResponse> =
+        listOf(
+            default().sample(),
+            second().sample(),
+        )
+}

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/BrowseGroupGenResponsesFixture.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/BrowseGroupGenResponsesFixture.kt
@@ -1,0 +1,46 @@
+package com.few.generator.fixture.usecase
+
+import com.few.generator.controller.response.BrowseGroupGenResponse
+import com.few.generator.controller.response.BrowseGroupGenResponses
+import com.few.generator.fixture.FixtureMonkeyConfig.builder
+import com.navercorp.fixturemonkey.kotlin.setExp
+
+/**
+ * BrowseGroupGenResponses를 위한 FixtureMonkey 기반 픽스쳐
+ */
+object BrowseGroupGenResponsesFixture {
+    /**
+     * 기본 랜덤 데이터로 생성
+     */
+    fun random(): BrowseGroupGenResponses =
+        com.few.generator.fixture.FixtureMonkeyConfig
+            .random()
+
+    /**
+     * 기본 테스트 데이터 빌더 (단일 그룹)
+     */
+    fun default() =
+        builder<BrowseGroupGenResponses>()
+            .setExp(BrowseGroupGenResponses::groups, listOf(BrowseGroupGenResponseFixture.default().sample()))
+
+    /**
+     * 빈 결과 빌더
+     */
+    fun empty() =
+        builder<BrowseGroupGenResponses>()
+            .setExp(BrowseGroupGenResponses::groups, emptyList<BrowseGroupGenResponse>())
+
+    /**
+     * 여러 그룹 포함 빌더
+     */
+    fun multiple() =
+        builder<BrowseGroupGenResponses>()
+            .setExp(BrowseGroupGenResponses::groups, BrowseGroupGenResponseFixture.multipleResponses())
+
+    /**
+     * 커스텀 그룹 리스트로 빌더 생성
+     */
+    fun withGroups(groups: List<BrowseGroupGenResponse>) =
+        builder<BrowseGroupGenResponses>()
+            .setExp(BrowseGroupGenResponses::groups, groups)
+}

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/ContentsFixture.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/ContentsFixture.kt
@@ -1,0 +1,89 @@
+package com.few.generator.fixture.usecase
+
+import com.few.generator.domain.Category
+import com.few.generator.domain.MediaType
+import com.few.generator.fixture.FixtureMonkeyConfig.builder
+import com.few.generator.usecase.out.ContentsUsecaseOut
+import com.navercorp.fixturemonkey.kotlin.setExp
+
+/**
+ * ContentsUsecaseOut을 위한 FixtureMonkey 기반 픽스쳐
+ */
+object ContentsFixture {
+    /**
+     * 기본 랜덤 데이터로 생성
+     */
+    fun random(): ContentsUsecaseOut =
+        com.few.generator.fixture.FixtureMonkeyConfig
+            .random()
+
+    /**
+     * 테스트용 기본 데이터 빌더
+     */
+    fun default() =
+        builder<ContentsUsecaseOut>()
+            .setExp(ContentsUsecaseOut::id, 1L)
+            .setExp(ContentsUsecaseOut::url, "https://example.com/news/1")
+            .setExp(ContentsUsecaseOut::thumbnailImageUrl, "https://example.com/thumb/1.jpg")
+            .setExp(ContentsUsecaseOut::mediaType, MediaType.CHOSUN)
+            .setExp(ContentsUsecaseOut::headline, "테스트 헤드라인")
+            .setExp(ContentsUsecaseOut::summary, "테스트 요약")
+            .setExp(ContentsUsecaseOut::highlightTexts, listOf("하이라이트1", "하이라이트2"))
+            .setExp(ContentsUsecaseOut::category, Category.TECHNOLOGY)
+
+    /**
+     * 조선일보 뉴스 데이터 빌더
+     */
+    fun chosunNews() =
+        builder<ContentsUsecaseOut>()
+            .setExp(ContentsUsecaseOut::id, 1L)
+            .setExp(ContentsUsecaseOut::mediaType, MediaType.CHOSUN)
+            .setExp(ContentsUsecaseOut::category, Category.TECHNOLOGY)
+            .setExp(ContentsUsecaseOut::headline, "첫 번째 뉴스")
+            .setExp(ContentsUsecaseOut::summary, "첫 번째 요약")
+            .setExp(ContentsUsecaseOut::highlightTexts, listOf("첫 번째 하이라이트"))
+
+    /**
+     * 경향신문 뉴스 데이터 빌더
+     */
+    fun khanNews() =
+        builder<ContentsUsecaseOut>()
+            .setExp(ContentsUsecaseOut::id, 2L)
+            .setExp(ContentsUsecaseOut::url, "https://example.com/news/2")
+            .setExp(ContentsUsecaseOut::thumbnailImageUrl, "https://example.com/thumb/2.jpg")
+            .setExp(ContentsUsecaseOut::mediaType, MediaType.KHAN)
+            .setExp(ContentsUsecaseOut::category, Category.LIFE)
+            .setExp(ContentsUsecaseOut::headline, "두 번째 뉴스")
+            .setExp(ContentsUsecaseOut::summary, "두 번째 요약")
+            .setExp(ContentsUsecaseOut::highlightTexts, listOf("두 번째 하이라이트"))
+
+    /**
+     * 여러 콘텐츠 리스트
+     */
+    fun multipleContents(): List<ContentsUsecaseOut> =
+        listOf(
+            chosunNews().sample(),
+            khanNews().sample(),
+        )
+
+    /**
+     * 특정 미디어 타입으로 빌더 생성
+     */
+    fun withMediaType(mediaType: MediaType) =
+        builder<ContentsUsecaseOut>()
+            .setExp(ContentsUsecaseOut::mediaType, mediaType)
+
+    /**
+     * 특정 카테고리로 빌더 생성
+     */
+    fun withCategory(category: Category) =
+        builder<ContentsUsecaseOut>()
+            .setExp(ContentsUsecaseOut::category, category)
+
+    /**
+     * 커스텀 헤드라인으로 빌더 생성
+     */
+    fun withHeadline(headline: String) =
+        builder<ContentsUsecaseOut>()
+            .setExp(ContentsUsecaseOut::headline, headline)
+}

--- a/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/GroupSourceHeadlineDataFixture.kt
+++ b/domain/generator/src/testFixtures/kotlin/com/few/generator/fixture/usecase/GroupSourceHeadlineDataFixture.kt
@@ -1,0 +1,42 @@
+package com.few.generator.fixture.usecase
+
+import com.few.generator.controller.response.GroupSourceHeadlineData
+import com.few.generator.fixture.FixtureMonkeyConfig.builder
+import com.navercorp.fixturemonkey.kotlin.setExp
+
+/**
+ * GroupSourceHeadlineData를 위한 FixtureMonkey 기반 픽스쳐
+ */
+object GroupSourceHeadlineDataFixture {
+    /**
+     * 기본 랜덤 데이터로 생성
+     */
+    fun random(): GroupSourceHeadlineData =
+        com.few.generator.fixture.FixtureMonkeyConfig
+            .random()
+
+    /**
+     * 기본 테스트 데이터 빌더
+     */
+    fun default() =
+        builder<GroupSourceHeadlineData>()
+            .setExp(GroupSourceHeadlineData::headline, "소스 헤드라인1")
+            .setExp(GroupSourceHeadlineData::url, "https://example.com/1")
+
+    /**
+     * 두 번째 테스트 데이터 빌더
+     */
+    fun second() =
+        builder<GroupSourceHeadlineData>()
+            .setExp(GroupSourceHeadlineData::headline, "소스 헤드라인2")
+            .setExp(GroupSourceHeadlineData::url, "https://example.com/2")
+
+    /**
+     * 여러 소스 헤드라인 데이터 생성
+     */
+    fun multipleHeadlines(): List<GroupSourceHeadlineData> =
+        listOf(
+            default().sample(),
+            second().sample(),
+        )
+}


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #711 

💁‍♂️ PR 내용
----
- Gen 관련 테스트 코드 작성

🙏 작업
----
- 클로드와 함께 테스트 코드 작성 하였습니다.
- jacoco로 테스트 결과 리포트 설정도 추가하였습니다.

🙈 PR 참고 사항
----

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 도메인 및 서비스, 컨트롤러, 유틸리티에 대한 다양한 단위 및 통합 테스트가 추가되었습니다.
  * FixtureMonkey 기반 테스트 픽스처 및 랜덤 데이터 생성 도구가 도입되었습니다.
  * 테스트 전용 Spring 설정 및 테스트 리소스 파일이 추가되었습니다.

* **새로운 기능**
  * 코드 커버리지 측정을 위한 Jacoco 플러그인이 빌드 구성에 추가되었습니다.
  * 테스트 구현을 위한 Kotest 관련 의존성이 추가되었습니다.

* **문서화**
  * 테스트 및 빌드 설정을 위한 예시 및 설명 주석이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->