### PR TITLE
[Feat/#716] provider 모듈 신규 생성 및 이메일 구독 API 신규 추가

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(project(":library:common"))
     /** domain */
     implementation(project(":domain:generator"))
+    implementation(project(":domain:provider"))
 
     /** starter */
     implementation("org.springframework.boot:spring-boot-starter-actuator")

--- a/api/src/main/kotlin/com/few/api/ApiMain.kt
+++ b/api/src/main/kotlin/com/few/api/ApiMain.kt
@@ -1,6 +1,7 @@
 package com.few.api
 
 import com.few.generator.config.GeneratorConfig
+import com.few.provider.config.ProviderConfig
 import common.config.CommonConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Import
 @Import(
     CommonConfig::class,
     GeneratorConfig::class,
+    ProviderConfig::class,
 )
 @SpringBootApplication
 class ApiMain

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
                 - web-local
                 # domain
                 - generator-local
+                - provider-local
             prd:
                 # library
                 - email-prd
@@ -20,6 +21,7 @@ spring:
                 - web-prd
                 # domain
                 - generator-prd
+                - provider-prd
     jpa:
         show-sql: true
         properties:

--- a/domain/generator/build.gradle.kts
+++ b/domain/generator/build.gradle.kts
@@ -8,6 +8,7 @@ tasks.getByName("jar") {
 
 dependencies {
     implementation(project(":library:web"))
+    implementation(project(":library:common"))
 
     /** starter */
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
@@ -1,13 +1,13 @@
 package com.few.generator.controller
 
 import com.few.generator.controller.response.*
-import com.few.generator.domain.Category
 import com.few.generator.service.GroupGenService
 import com.few.generator.usecase.BrowseContentsUseCase
 import com.few.generator.usecase.GroupGenBrowseUseCase
 import com.few.generator.usecase.RawContentsBrowseContentUseCase
 import com.few.generator.usecase.SchedulingUseCase
 import com.few.generator.usecase.input.BrowseContentsUseCaseIn
+import common.domain.Category
 import jakarta.validation.constraints.Min
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus

--- a/domain/generator/src/main/kotlin/com/few/generator/core/connection/RetryableJsoup.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/connection/RetryableJsoup.kt
@@ -1,12 +1,12 @@
 package com.few.generator.core.connection
 
 import com.few.generator.config.JsoupConnectionFactory
+import common.exception.BadRequestException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jsoup.HttpStatusException
 import org.jsoup.nodes.Document
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-import web.handler.exception.BadRequestException
 import java.util.concurrent.TimeUnit
 
 @Service

--- a/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/Scrapper.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/Scrapper.kt
@@ -3,7 +3,7 @@ package com.few.generator.core.scrapper
 import com.few.generator.core.connection.RetryableJsoup
 import com.few.generator.core.scrapper.naver.NaverExtractor
 import com.few.generator.core.scrapper.naver.NaverScrapper
-import com.few.generator.domain.Category
+import common.domain.Category
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
 

--- a/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/naver/NaverConstants.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/naver/NaverConstants.kt
@@ -1,7 +1,7 @@
 package com.few.generator.core.scrapper.naver
 
-import com.few.generator.domain.Category
-import com.few.generator.domain.ImageSuffix
+import common.domain.Category
+import common.domain.ImageSuffix
 
 object NaverConstants {
     val SUPPORT_IMAGE_SUFFIX = ImageSuffix.entries.map { it.extension.lowercase() }

--- a/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/naver/NaverScrapper.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/naver/NaverScrapper.kt
@@ -2,8 +2,8 @@ package com.few.generator.core.scrapper.naver
 
 import com.few.generator.core.connection.RetryableJsoup
 import com.few.generator.core.scrapper.ScrappedResult
-import com.few.generator.domain.Category
-import com.few.generator.domain.MediaType
+import common.domain.Category
+import common.domain.MediaType
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jsoup.nodes.Document
 import org.springframework.stereotype.Service

--- a/domain/generator/src/main/kotlin/com/few/generator/service/GenService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/GenService.kt
@@ -6,12 +6,12 @@ import com.few.generator.core.gpt.prompt.PromptGenerator
 import com.few.generator.core.gpt.prompt.schema.Headline
 import com.few.generator.core.gpt.prompt.schema.HighlightText
 import com.few.generator.core.gpt.prompt.schema.Summary
-import com.few.generator.domain.Category
 import com.few.generator.domain.Gen
 import com.few.generator.domain.ProvisioningContents
 import com.few.generator.domain.RawContents
 import com.few.generator.repository.GenRepository
 import com.google.gson.Gson
+import common.domain.Category
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service

--- a/domain/generator/src/main/kotlin/com/few/generator/service/GroupContentGenerationService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/GroupContentGenerationService.kt
@@ -7,7 +7,6 @@ import com.few.generator.core.gpt.prompt.schema.Group
 import com.few.generator.core.gpt.prompt.schema.Headline
 import com.few.generator.core.gpt.prompt.schema.HighlightTexts
 import com.few.generator.core.gpt.prompt.schema.Summary
-import com.few.generator.domain.Category
 import com.few.generator.domain.Gen
 import com.few.generator.domain.GroupGen
 import com.few.generator.domain.ProvisioningContents
@@ -15,6 +14,7 @@ import com.few.generator.domain.vo.GroupSourceHeadline
 import com.few.generator.repository.GroupGenRepository
 import com.few.generator.repository.RawContentsRepository
 import com.google.gson.Gson
+import common.domain.Category
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service

--- a/domain/generator/src/main/kotlin/com/few/generator/service/GroupGenMetricsService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/GroupGenMetricsService.kt
@@ -1,6 +1,6 @@
 package com.few.generator.service
 
-import com.few.generator.domain.Category
+import common.domain.Category
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 

--- a/domain/generator/src/main/kotlin/com/few/generator/service/GroupGenService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/GroupGenService.kt
@@ -2,7 +2,6 @@ package com.few.generator.service
 
 import com.few.generator.config.GeneratorGsonConfig.Companion.GSON_BEAN_NAME
 import com.few.generator.config.GroupingProperties
-import com.few.generator.domain.Category
 import com.few.generator.domain.GroupGen
 import com.few.generator.domain.vo.GenDetail
 import com.few.generator.domain.vo.GroupGenProcessingResult
@@ -10,6 +9,7 @@ import com.few.generator.repository.GenRepository
 import com.few.generator.repository.ProvisioningContentsRepository
 import com.few.generator.support.jpa.GeneratorTransactional
 import com.google.gson.Gson
+import common.domain.Category
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/domain/generator/src/main/kotlin/com/few/generator/service/GroupingService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/GroupingService.kt
@@ -4,8 +4,8 @@ import com.few.generator.config.GroupingProperties
 import com.few.generator.core.gpt.ChatGpt
 import com.few.generator.core.gpt.prompt.PromptGenerator
 import com.few.generator.core.gpt.prompt.schema.Group
-import com.few.generator.domain.Category
 import com.few.generator.domain.vo.GenDetail
+import common.domain.Category
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 

--- a/domain/generator/src/main/kotlin/com/few/generator/service/ProvisioningService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/ProvisioningService.kt
@@ -8,10 +8,10 @@ import com.few.generator.domain.ProvisioningContents
 import com.few.generator.domain.RawContents
 import com.few.generator.repository.ProvisioningContentsRepository
 import com.google.gson.Gson
+import common.exception.BadRequestException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
-import web.handler.exception.BadRequestException
 
 @Service
 class ProvisioningService(

--- a/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
@@ -2,15 +2,15 @@ package com.few.generator.service
 
 import com.few.generator.config.GeneratorGsonConfig.Companion.GSON_BEAN_NAME
 import com.few.generator.core.scrapper.Scrapper
-import com.few.generator.domain.Category
-import com.few.generator.domain.MediaType
 import com.few.generator.domain.RawContents
 import com.few.generator.repository.RawContentsRepository
 import com.google.gson.Gson
+import common.domain.Category
+import common.domain.MediaType
+import common.exception.BadRequestException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
-import web.handler.exception.BadRequestException
 
 @Service
 class RawContentsService(

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
@@ -1,8 +1,6 @@
 package com.few.generator.usecase
 
 import com.few.generator.config.GeneratorGsonConfig.Companion.GSON_BEAN_NAME
-import com.few.generator.domain.Category
-import com.few.generator.domain.MediaType
 import com.few.generator.repository.GenRepository
 import com.few.generator.repository.ProvisioningContentsRepository
 import com.few.generator.repository.RawContentsRepository
@@ -12,6 +10,8 @@ import com.few.generator.usecase.out.BrowseContentsUsecaseOuts
 import com.few.generator.usecase.out.ContentsUsecaseOut
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import common.domain.Category
+import common.domain.MediaType
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/GroupGenBrowseUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/GroupGenBrowseUseCase.kt
@@ -1,11 +1,13 @@
 package com.few.generator.usecase
 
+import com.few.generator.config.GeneratorGsonConfig
 import com.few.generator.controller.response.BrowseGroupGenResponse
 import com.few.generator.controller.response.BrowseGroupGenResponses
 import com.few.generator.controller.response.GroupSourceHeadlineData
 import com.few.generator.repository.GroupGenRepository
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 import java.time.LocalTime
@@ -13,6 +15,7 @@ import java.time.LocalTime
 @Component
 data class GroupGenBrowseUseCase(
     private val groupGenRepository: GroupGenRepository,
+    @Qualifier(GeneratorGsonConfig.GSON_BEAN_NAME)
     private val gson: Gson,
 ) {
     fun execute(date: LocalDate?): BrowseGroupGenResponses {

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/GroupSchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/GroupSchedulingUseCase.kt
@@ -3,11 +3,11 @@ package com.few.generator.usecase
 import com.few.generator.event.dto.ContentsSchedulingEventDto
 import com.few.generator.service.GroupGenService
 import com.few.generator.support.jpa.GeneratorTransactional
+import common.exception.BadRequestException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import web.handler.exception.BadRequestException
 import java.time.LocalDateTime
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.measureTimeMillis

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/RawContentsBrowseContentUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/RawContentsBrowseContentUseCase.kt
@@ -9,6 +9,8 @@ import com.few.generator.support.jpa.GeneratorTransactional
 import com.few.generator.usecase.out.*
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import common.domain.Category
+import common.domain.MediaType
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/SchedulingUseCase.kt
@@ -6,12 +6,12 @@ import com.few.generator.service.GenService
 import com.few.generator.service.ProvisioningService
 import com.few.generator.service.RawContentsService
 import com.few.generator.support.jpa.GeneratorTransactional
+import common.exception.BadRequestException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import web.handler.exception.BadRequestException
 import java.time.LocalDateTime
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.measureTimeMillis

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/input/BrowseContentsUseCaseIn.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/input/BrowseContentsUseCaseIn.kt
@@ -1,7 +1,7 @@
 package com.few.generator.usecase.input
 
-import com.few.generator.domain.Category
-import web.handler.exception.BadRequestException
+import common.domain.Category
+import common.exception.BadRequestException
 
 data class BrowseContentsUseCaseIn(
     val prevGenId: Long,

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/out/BrowseContentsUsecaseOut.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/out/BrowseContentsUsecaseOut.kt
@@ -1,7 +1,7 @@
 package com.few.generator.usecase.out
 
-import com.few.generator.domain.Category
-import com.few.generator.domain.MediaType
+import common.domain.Category
+import common.domain.MediaType
 import java.time.LocalDateTime
 
 data class BrowseContentsUsecaseOut(

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/out/BrowseContentsUsecaseOuts.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/out/BrowseContentsUsecaseOuts.kt
@@ -1,7 +1,7 @@
 package com.few.generator.usecase.out
 
-import com.few.generator.domain.Category
-import com.few.generator.domain.MediaType
+import common.domain.Category
+import common.domain.MediaType
 import java.time.LocalDateTime
 
 data class BrowseContentsUsecaseOuts(

--- a/domain/provider/build.gradle.kts
+++ b/domain/provider/build.gradle.kts
@@ -8,6 +8,7 @@ tasks.getByName("jar") {
 
 dependencies {
     implementation(project(":library:web"))
+    implementation(project(":library:common"))
 
     /** starter **/
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/domain/provider/build.gradle.kts
+++ b/domain/provider/build.gradle.kts
@@ -1,0 +1,23 @@
+tasks.getByName("bootJar") {
+    enabled = false
+}
+
+tasks.getByName("jar") {
+    enabled = true
+}
+
+dependencies {
+    implementation(project(":library:web"))
+
+    /** starter **/
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    /** swagger **/
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${DependencyVersion.SPRINGDOC_OPENAPI}")
+
+    /** mysql **/
+    implementation("com.mysql:mysql-connector-j")
+
+    /** gson **/
+    implementation("com.google.code.gson:gson:${DependencyVersion.GSON}")
+}

--- a/domain/provider/build.gradle.kts
+++ b/domain/provider/build.gradle.kts
@@ -6,6 +6,10 @@ tasks.getByName("jar") {
     enabled = true
 }
 
+plugins {
+    kotlin("plugin.jpa") version "1.9.0"
+}
+
 dependencies {
     implementation(project(":library:web"))
     implementation(project(":library:common"))

--- a/domain/provider/src/main/kotlin/com/few/provider/config/ProviderConfig.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/config/ProviderConfig.kt
@@ -1,0 +1,22 @@
+package com.few.provider.config
+
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import security.config.SecurityConfig
+import web.config.WebConfig
+
+@Configuration
+@ComponentScan(basePackages = [ProviderConfig.BASE_PACKAGE])
+@Import(
+    value = [
+        WebConfig::class,
+        SecurityConfig::class,
+    ],
+)
+class ProviderConfig {
+    companion object {
+        const val BASE_PACKAGE = "com.few.provider"
+        const val BEAN_NAME_PREFIX = "fewProvider"
+    }
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/config/ProviderDataSourceConfig.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/config/ProviderDataSourceConfig.kt
@@ -1,0 +1,42 @@
+package com.few.provider.config
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ProviderDataSourceConfig {
+    companion object {
+        const val DATASOURCE = ProviderConfig.BEAN_NAME_PREFIX + "DataSource"
+        const val DATASOURCE_PROPERTIES = ProviderConfig.BEAN_NAME_PREFIX + "DataSourceProperties"
+    }
+
+    @Bean(name = [DATASOURCE])
+    fun dataSource(
+        @Qualifier(DATASOURCE_PROPERTIES) dataSourceProperties: DataSourceProperties,
+    ): HikariDataSource {
+        val hikariConfig =
+            HikariConfig().apply {
+                jdbcUrl = dataSourceProperties.url
+                username = dataSourceProperties.username
+                password = dataSourceProperties.password
+                driverClassName = dataSourceProperties.driverClassName
+                poolName = "Provider-POOL"
+                maximumPoolSize = 16
+                minimumIdle = 4
+                connectionTimeout = 30000
+                idleTimeout = 300000
+                maxLifetime = 1800000
+                connectionTestQuery = "SELECT 1"
+            }
+        return HikariDataSource(hikariConfig)
+    }
+
+    @Bean(name = [DATASOURCE_PROPERTIES])
+    @ConfigurationProperties(prefix = "spring.provider.datasource")
+    fun dataSourceProperties(): DataSourceProperties = DataSourceProperties()
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/config/ProviderGsonConfig.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/config/ProviderGsonConfig.kt
@@ -1,0 +1,43 @@
+package com.few.provider.config
+
+import com.google.gson.*
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.lang.reflect.Type
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Configuration
+class ProviderGsonConfig {
+    companion object {
+        const val GSON_BEAN_NAME = ProviderConfig.BEAN_NAME_PREFIX + "Gson"
+    }
+
+    @Bean(GSON_BEAN_NAME)
+    fun gson(): Gson =
+        GsonBuilder()
+            .setLenient()
+            .disableHtmlEscaping()
+            .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeAdapter())
+            .create()
+}
+
+class LocalDateTimeAdapter :
+    JsonSerializer<LocalDateTime>,
+    JsonDeserializer<LocalDateTime> {
+    private val formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+
+    override fun serialize(
+        src: LocalDateTime,
+        typeOfSrc: Type,
+        context: JsonSerializationContext,
+    ): JsonElement = JsonPrimitive(src.format(formatter))
+
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext,
+    ): LocalDateTime = LocalDateTime.parse(json.asString, formatter)
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/config/ProviderJpaConfig.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/config/ProviderJpaConfig.kt
@@ -1,0 +1,118 @@
+package com.few.provider.config
+
+import jakarta.persistence.EntityManagerFactory
+import org.hibernate.cfg.AvailableSettings
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+import org.springframework.boot.autoconfigure.orm.jpa.*
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.orm.hibernate5.SpringBeanContainer
+import org.springframework.orm.jpa.JpaTransactionManager
+import org.springframework.orm.jpa.JpaVendorAdapter
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean
+import org.springframework.orm.jpa.persistenceunit.PersistenceUnitManager
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.EnableTransactionManagement
+import org.springframework.util.ClassUtils
+import javax.sql.DataSource
+
+@Configuration
+// @EnableJpaAuditing // TODO: generator 모듈에서와 중복됨(프로젝트 당 1개필요)
+@EnableTransactionManagement
+@EnableJpaRepositories(
+    basePackages = [ProviderConfig.BASE_PACKAGE],
+    entityManagerFactoryRef = ProviderJpaConfig.ENTITY_MANAGER_FACTORY,
+    transactionManagerRef = ProviderJpaConfig.TRANSACTION_MANAGER,
+)
+@Import(
+    value = [
+        ProviderDataSourceConfig::class,
+    ],
+)
+@EnableAutoConfiguration(
+    exclude = [
+        DataSourceAutoConfiguration::class,
+        DataSourceTransactionManagerAutoConfiguration::class,
+        HibernateJpaAutoConfiguration::class,
+    ],
+)
+class ProviderJpaConfig {
+    companion object {
+        const val JPA_PROPERTIES = ProviderConfig.BEAN_NAME_PREFIX + "JpaProperties"
+        const val HIBERNATE_PROPERTIES = ProviderConfig.BEAN_NAME_PREFIX + "HibernateProperties"
+        const val JPA_VENDOR_ADAPTER = ProviderConfig.BEAN_NAME_PREFIX + "JpaVendorAdapter"
+        const val ENTITY_MANAGER_FACTORY_BUILDER = ProviderConfig.BEAN_NAME_PREFIX + "EntityManagerFactoryBuilder"
+        const val ENTITY_MANAGER_FACTORY = ProviderConfig.BEAN_NAME_PREFIX + "EntityManagerFactory"
+        const val TRANSACTION_MANAGER = ProviderConfig.BEAN_NAME_PREFIX + "TransactionManager"
+    }
+
+    @Bean(name = [ENTITY_MANAGER_FACTORY])
+    fun entityManagerFactory(
+        @Qualifier(ProviderDataSourceConfig.DATASOURCE)
+        dataSource: DataSource,
+        @Qualifier(ENTITY_MANAGER_FACTORY_BUILDER)
+        builder: EntityManagerFactoryBuilder,
+        beanFactory: ConfigurableListableBeanFactory,
+    ): LocalContainerEntityManagerFactoryBean {
+        val jpaPropertyMap = jpaProperties().properties
+        val settings = HibernateSettings()
+        if (ClassUtils.isPresent("org.hibernate.resource.beans.container.spi.BeanContainer", javaClass.classLoader)) {
+            val customizer =
+                HibernatePropertiesCustomizer { properties: MutableMap<String?, Any?> ->
+                    properties[AvailableSettings.BEAN_CONTAINER] = SpringBeanContainer(beanFactory)
+                }
+            settings.hibernatePropertiesCustomizers(listOf(customizer))
+        }
+        val hibernatePropertyMap =
+            hibernateProperties().determineHibernateProperties(jpaPropertyMap, settings)
+
+        return builder
+            .dataSource(dataSource)
+            .properties(hibernatePropertyMap)
+            .packages(ProviderConfig.BASE_PACKAGE)
+            .build()
+    }
+
+    @Bean(name = [TRANSACTION_MANAGER])
+    fun transactionManager(
+        @Qualifier(ENTITY_MANAGER_FACTORY)
+        emf: EntityManagerFactory,
+    ): PlatformTransactionManager = JpaTransactionManager(emf)
+
+    @Bean(name = [JPA_PROPERTIES])
+    @ConfigurationProperties("spring.provider.jpa")
+    fun jpaProperties(): JpaProperties = JpaProperties()
+
+    @Bean(name = [HIBERNATE_PROPERTIES])
+    @ConfigurationProperties("spring.provider.jpa.hibernate")
+    fun hibernateProperties(): HibernateProperties = HibernateProperties()
+
+    @Bean(name = [JPA_VENDOR_ADAPTER])
+    fun jpaVendorAdapter(): JpaVendorAdapter = HibernateJpaVendorAdapter()
+
+    @Bean(name = [ENTITY_MANAGER_FACTORY_BUILDER])
+    fun entityManagerFactoryBuilder(
+        @Qualifier(JPA_VENDOR_ADAPTER)
+        jpaVendorAdapter: JpaVendorAdapter,
+        @Qualifier(JPA_PROPERTIES)
+        jpaProperties: JpaProperties,
+        persistenceUnitManager: ObjectProvider<PersistenceUnitManager>,
+    ): EntityManagerFactoryBuilder {
+        val jpaPropertyMap = jpaProperties.properties
+        return EntityManagerFactoryBuilder(
+            jpaVendorAdapter,
+            jpaPropertyMap,
+            persistenceUnitManager.getIfAvailable(),
+        )
+    }
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
@@ -31,8 +31,7 @@ class SubscriptionController(
 
         return ApiResponseGenerator.success(
             EnrollSubscriptionResponse(
-                ucOuts.existingCategories.map { CodeValueResponse(it.code, it.title) },
-                ucOuts.newCategories.map { CodeValueResponse(it.code, it.title) },
+                ucOuts.subscribedCategories.map { CodeValueResponse(it.code, it.title) },
             ),
             HttpStatus.CREATED,
         )

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
@@ -1,5 +1,9 @@
 package com.few.provider.controller
 
+import com.few.provider.controller.request.EnrollSubscriptionRequest
+import com.few.provider.controller.response.EnrollSubscriptionResponse
+import com.few.provider.usecase.EnrollSubscriptionUseCase
+import com.few.provider.usecase.input.EnrollSubscriptionUseCaseIn
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
@@ -9,12 +13,21 @@ import web.ApiResponseGenerator
 @Validated
 @RestController
 @RequestMapping("/api/v1")
-class SubscriptionController {
-    @PostMapping(
-        value = ["/subscriptions"],
-    )
-    fun example(): ApiResponse<ApiResponse.Success> =
-        ApiResponseGenerator.success(
-            HttpStatus.OK,
-        )
+class SubscriptionController(
+    private val enrollSubscriptionUseCase: EnrollSubscriptionUseCase,
+) {
+    @PostMapping("/subscriptions")
+    fun enrollSubscription(
+        @Validated @RequestBody request: EnrollSubscriptionRequest,
+    ): ApiResponse<ApiResponse.SuccessBody<EnrollSubscriptionResponse>> {
+        val ucOuts =
+            enrollSubscriptionUseCase.execute(
+                EnrollSubscriptionUseCaseIn(
+                    email = request.email,
+                    categoryCodes = request.categoryCodes,
+                ),
+            )
+
+        return ApiResponseGenerator.success(EnrollSubscriptionResponse(ucOuts.existingCategories, ucOuts.newCategories), HttpStatus.CREATED)
+    }
 }

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
@@ -1,6 +1,7 @@
 package com.few.provider.controller
 
 import com.few.provider.controller.request.EnrollSubscriptionRequest
+import com.few.provider.controller.response.CodeValueResponse
 import com.few.provider.controller.response.EnrollSubscriptionResponse
 import com.few.provider.usecase.EnrollSubscriptionUseCase
 import com.few.provider.usecase.input.EnrollSubscriptionUseCaseIn
@@ -28,6 +29,12 @@ class SubscriptionController(
                 ),
             )
 
-        return ApiResponseGenerator.success(EnrollSubscriptionResponse(ucOuts.existingCategories, ucOuts.newCategories), HttpStatus.CREATED)
+        return ApiResponseGenerator.success(
+            EnrollSubscriptionResponse(
+                ucOuts.existingCategories.map { CodeValueResponse(it.code, it.title) },
+                ucOuts.newCategories.map { CodeValueResponse(it.code, it.title) },
+            ),
+            HttpStatus.CREATED,
+        )
     }
 }

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
@@ -1,0 +1,20 @@
+package com.few.provider.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+import web.ApiResponse
+import web.ApiResponseGenerator
+
+@Validated
+@RestController
+@RequestMapping("/api/v1")
+class SubscriptionController {
+    @PostMapping(
+        value = ["/subscriptions"],
+    )
+    fun example(): ApiResponse<ApiResponse.Success> =
+        ApiResponseGenerator.success(
+            HttpStatus.OK,
+        )
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
@@ -3,7 +3,9 @@ package com.few.provider.controller
 import com.few.provider.controller.request.EnrollSubscriptionRequest
 import com.few.provider.controller.response.CodeValueResponse
 import com.few.provider.controller.response.EnrollSubscriptionResponse
+import com.few.provider.usecase.BrowseSubscriptionUseCase
 import com.few.provider.usecase.EnrollSubscriptionUseCase
+import com.few.provider.usecase.input.BrowseSubscriptionUseCaseIn
 import com.few.provider.usecase.input.EnrollSubscriptionUseCaseIn
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
@@ -16,6 +18,7 @@ import web.ApiResponseGenerator
 @RequestMapping("/api/v1")
 class SubscriptionController(
     private val enrollSubscriptionUseCase: EnrollSubscriptionUseCase,
+    private val browseSubscriptionUseCase: BrowseSubscriptionUseCase,
 ) {
     @PostMapping("/subscriptions")
     fun enrollSubscription(
@@ -34,6 +37,25 @@ class SubscriptionController(
                 ucOuts.subscribedCategories.map { CodeValueResponse(it.code, it.title) },
             ),
             HttpStatus.CREATED,
+        )
+    }
+
+    @GetMapping("/subscriptions")
+    fun browseSubscription(
+        @RequestHeader("email") email: String, // TODO: auth 적용
+    ): ApiResponse<ApiResponse.SuccessBody<EnrollSubscriptionResponse>> {
+        val ucOuts =
+            browseSubscriptionUseCase.execute(
+                BrowseSubscriptionUseCaseIn(
+                    email,
+                ),
+            )
+
+        return ApiResponseGenerator.success(
+            EnrollSubscriptionResponse(
+                ucOuts.subscribedCategories.map { CodeValueResponse(it.code, it.title) },
+            ),
+            HttpStatus.OK,
         )
     }
 }

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/request/EnrollSubscriptionRequest.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/request/EnrollSubscriptionRequest.kt
@@ -1,0 +1,13 @@
+package com.few.provider.controller.request
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+
+data class EnrollSubscriptionRequest(
+    @field:NotNull(message = "이메일은 필수입니다")
+    @field:Email(message = "올바른 이메일 형식이 아닙니다")
+    val email: String,
+    @field:NotEmpty(message = "카테고리는 최소 1개 이상 선택해야 합니다")
+    val categoryCodes: List<Int>,
+)

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/request/EnrollSubscriptionRequest.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/request/EnrollSubscriptionRequest.kt
@@ -1,13 +1,19 @@
 package com.few.provider.controller.request
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 
-data class EnrollSubscriptionRequest(
-    @field:NotNull(message = "이메일은 필수입니다")
-    @field:Email(message = "올바른 이메일 형식이 아닙니다")
-    val email: String,
-    @field:NotEmpty(message = "카테고리는 최소 1개 이상 선택해야 합니다")
-    val categoryCodes: List<Int>,
-)
+data class EnrollSubscriptionRequest
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    constructor(
+        @field:NotNull(message = "이메일은 필수입니다")
+        @field:Email(message = "올바른 이메일 형식이 아닙니다")
+        @JsonProperty("email")
+        val email: String,
+        @field:NotEmpty(message = "카테고리는 최소 1개 이상 선택해야 합니다")
+        @JsonProperty("categoryCodes")
+        val categoryCodes: List<Int>,
+    )

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/response/CodeValueResponse.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/response/CodeValueResponse.kt
@@ -1,0 +1,6 @@
+package com.few.provider.controller.response
+
+data class CodeValueResponse(
+    val code: Int,
+    val value: String,
+)

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/response/EnrollSubscriptionResponse.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/response/EnrollSubscriptionResponse.kt
@@ -1,0 +1,6 @@
+package com.few.provider.controller.response
+
+class EnrollSubscriptionResponse(
+    val existingCategories: List<Int>,
+    val newCategories: List<Int>,
+)

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/response/EnrollSubscriptionResponse.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/response/EnrollSubscriptionResponse.kt
@@ -1,6 +1,6 @@
 package com.few.provider.controller.response
 
 class EnrollSubscriptionResponse(
-    val existingCategories: List<Int>,
-    val newCategories: List<Int>,
+    val existingCategories: List<CodeValueResponse>,
+    val newCategories: List<CodeValueResponse>,
 )

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/response/EnrollSubscriptionResponse.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/response/EnrollSubscriptionResponse.kt
@@ -1,6 +1,5 @@
 package com.few.provider.controller.response
 
 class EnrollSubscriptionResponse(
-    val existingCategories: List<CodeValueResponse>,
-    val newCategories: List<CodeValueResponse>,
+    val subscribedCategories: List<CodeValueResponse>,
 )

--- a/domain/provider/src/main/kotlin/com/few/provider/domain/BaseEntity.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/domain/BaseEntity.kt
@@ -1,0 +1,16 @@
+package com.few.provider.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    var createdAt: LocalDateTime? = null
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/domain/Subscription.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/domain/Subscription.kt
@@ -12,6 +12,6 @@ import jakarta.persistence.*
 )
 class Subscription(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) var id: Long? = null,
-    @Column(unique = true, length = 100) var email: String,
+    @Column(length = 100) var email: String,
     @Column(name = "categories", length = 100) var categories: String,
 ) : BaseEntity()

--- a/domain/provider/src/main/kotlin/com/few/provider/domain/Subscription.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/domain/Subscription.kt
@@ -7,15 +7,11 @@ import jakarta.persistence.*
     name = "subscription",
     indexes =
         [
-            Index(
-                name = "idx_subscription_email_category",
-                columnList = "email, category_code",
-            ),
-            Index(name = "idx_subscription_email", columnList = "email"),
+            Index(name = "idx_subscription_email", columnList = "email", unique = true),
         ],
 )
 class Subscription(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) var id: Long? = null,
-    @Column(unique = true) var email: String,
-    @Column var category: Int,
+    @Column(unique = true, length = 100) var email: String,
+    @Column(name = "categories", length = 100) var categories: String,
 ) : BaseEntity()

--- a/domain/provider/src/main/kotlin/com/few/provider/domain/Subscription.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/domain/Subscription.kt
@@ -1,0 +1,21 @@
+package com.few.provider.domain
+
+import jakarta.persistence.*
+
+@Entity
+@Table(
+    name = "subscription",
+    indexes =
+        [
+            Index(
+                name = "idx_subscription_email_category",
+                columnList = "email, category_code",
+            ),
+            Index(name = "idx_subscription_email", columnList = "email"),
+        ],
+)
+class Subscription(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) var id: Long? = null,
+    @Column(unique = true) var email: String,
+    @Column var category: Int,
+) : BaseEntity()

--- a/domain/provider/src/main/kotlin/com/few/provider/domain/SubscriptionAction.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/domain/SubscriptionAction.kt
@@ -1,0 +1,13 @@
+package com.few.provider.domain
+
+enum class SubscriptionAction(
+    val code: Int,
+) {
+    ENROLL(1),
+    CANCEL(2),
+    ;
+
+    companion object {
+        fun fromCode(code: Int) = SubscriptionAction.entries.first { it.code == code }
+    }
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/domain/SubscriptionHis.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/domain/SubscriptionHis.kt
@@ -1,0 +1,22 @@
+package com.few.provider.domain
+
+import jakarta.persistence.*
+
+@Entity
+@Table(
+    name = "subscription_history",
+    indexes =
+        [
+            Index(name = "idx_subscription_his_email", columnList = "email"),
+            Index(
+                name = "idx_subscription_his_email_created",
+                columnList = "email, created_at",
+            ),
+        ],
+)
+class SubscriptionHis(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) var id: Long? = null,
+    @Column var email: String,
+    @Column var category: Int,
+    @Column var action: Int,
+) : BaseEntity()

--- a/domain/provider/src/main/kotlin/com/few/provider/domain/SubscriptionHis.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/domain/SubscriptionHis.kt
@@ -5,18 +5,10 @@ import jakarta.persistence.*
 @Entity
 @Table(
     name = "subscription_history",
-    indexes =
-        [
-            Index(name = "idx_subscription_his_email", columnList = "email"),
-            Index(
-                name = "idx_subscription_his_email_created",
-                columnList = "email, created_at",
-            ),
-        ],
 )
 class SubscriptionHis(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) var id: Long? = null,
     @Column var email: String,
-    @Column var category: Int,
+    @Column(name = "categories", length = 100) var categories: String,
     @Column var action: Int,
 ) : BaseEntity()

--- a/domain/provider/src/main/kotlin/com/few/provider/repository/SubscriptionHisRepository.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/repository/SubscriptionHisRepository.kt
@@ -1,0 +1,8 @@
+package com.few.provider.repository
+
+import com.few.provider.domain.SubscriptionHis
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface SubscriptionHisRepository : JpaRepository<SubscriptionHis, Long>

--- a/domain/provider/src/main/kotlin/com/few/provider/repository/SubscriptionRepository.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/repository/SubscriptionRepository.kt
@@ -6,8 +6,5 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface SubscriptionRepository : JpaRepository<Subscription, Long> {
-    fun findByEmailAndCategory(
-        email: String,
-        categoryCode: Int,
-    ): Subscription?
+    fun findByEmail(email: String): Subscription?
 }

--- a/domain/provider/src/main/kotlin/com/few/provider/repository/SubscriptionRepository.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/repository/SubscriptionRepository.kt
@@ -1,0 +1,13 @@
+package com.few.provider.repository
+
+import com.few.provider.domain.Subscription
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface SubscriptionRepository : JpaRepository<Subscription, Long> {
+    fun findByEmailAndCategory(
+        email: String,
+        categoryCode: Int,
+    ): Subscription?
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/support/jpa/GeneratorTransactional.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/support/jpa/GeneratorTransactional.kt
@@ -5,7 +5,6 @@ import org.springframework.core.annotation.AliasFor
 import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
-import kotlin.reflect.KClass
 
 /**
  * Api DataSource 트랜잭션을 처리하는 어노테이션
@@ -15,24 +14,10 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 @Transactional(transactionManager = ProviderJpaConfig.TRANSACTION_MANAGER)
 annotation class ProviderTransactional(
-    @get:AliasFor(annotation = Transactional::class, attribute = "label")
-    val label: Array<String> = [],
     @get:AliasFor(annotation = Transactional::class, attribute = "propagation")
     val propagation: Propagation = Propagation.REQUIRED,
     @get:AliasFor(annotation = Transactional::class, attribute = "isolation")
     val isolation: Isolation = Isolation.DEFAULT,
-    @get:AliasFor(annotation = Transactional::class, attribute = "timeout")
-    val timeout: Int = -1,
-    @get:AliasFor(annotation = Transactional::class, attribute = "timeoutString")
-    val timeoutString: String = "",
     @get:AliasFor(annotation = Transactional::class, attribute = "readOnly")
     val readOnly: Boolean = false,
-    @get:AliasFor(annotation = Transactional::class, attribute = "rollbackFor")
-    val rollbackFor: Array<KClass<out Throwable>> = [],
-    @get:AliasFor(annotation = Transactional::class, attribute = "rollbackForClassName")
-    val rollbackForClassName: Array<String> = [],
-    @get:AliasFor(annotation = Transactional::class, attribute = "noRollbackFor")
-    val noRollbackFor: Array<KClass<out Throwable>> = [],
-    @get:AliasFor(annotation = Transactional::class, attribute = "noRollbackForClassName")
-    val noRollbackForClassName: Array<String> = [],
 )

--- a/domain/provider/src/main/kotlin/com/few/provider/support/jpa/GeneratorTransactional.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/support/jpa/GeneratorTransactional.kt
@@ -1,0 +1,38 @@
+package com.few.provider.support.jpa
+
+import com.few.provider.config.ProviderJpaConfig
+import org.springframework.core.annotation.AliasFor
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import kotlin.reflect.KClass
+
+/**
+ * Api DataSource 트랜잭션을 처리하는 어노테이션
+ * transactionManager는 DataSourceConfig에서 설정한 값을 기본으로 사용한다.
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Transactional(transactionManager = ProviderJpaConfig.TRANSACTION_MANAGER)
+annotation class ProviderTransactional(
+    @get:AliasFor(annotation = Transactional::class, attribute = "label")
+    val label: Array<String> = [],
+    @get:AliasFor(annotation = Transactional::class, attribute = "propagation")
+    val propagation: Propagation = Propagation.REQUIRED,
+    @get:AliasFor(annotation = Transactional::class, attribute = "isolation")
+    val isolation: Isolation = Isolation.DEFAULT,
+    @get:AliasFor(annotation = Transactional::class, attribute = "timeout")
+    val timeout: Int = -1,
+    @get:AliasFor(annotation = Transactional::class, attribute = "timeoutString")
+    val timeoutString: String = "",
+    @get:AliasFor(annotation = Transactional::class, attribute = "readOnly")
+    val readOnly: Boolean = false,
+    @get:AliasFor(annotation = Transactional::class, attribute = "rollbackFor")
+    val rollbackFor: Array<KClass<out Throwable>> = [],
+    @get:AliasFor(annotation = Transactional::class, attribute = "rollbackForClassName")
+    val rollbackForClassName: Array<String> = [],
+    @get:AliasFor(annotation = Transactional::class, attribute = "noRollbackFor")
+    val noRollbackFor: Array<KClass<out Throwable>> = [],
+    @get:AliasFor(annotation = Transactional::class, attribute = "noRollbackForClassName")
+    val noRollbackForClassName: Array<String> = [],
+)

--- a/domain/provider/src/main/kotlin/com/few/provider/support/jpa/ProviderTransactional.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/support/jpa/ProviderTransactional.kt
@@ -5,6 +5,7 @@ import org.springframework.core.annotation.AliasFor
 import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import kotlin.reflect.KClass
 
 /**
  * Api DataSource 트랜잭션을 처리하는 어노테이션
@@ -14,10 +15,24 @@ import org.springframework.transaction.annotation.Transactional
 @Retention(AnnotationRetention.RUNTIME)
 @Transactional(transactionManager = ProviderJpaConfig.TRANSACTION_MANAGER)
 annotation class ProviderTransactional(
+    @get:AliasFor(annotation = Transactional::class, attribute = "label")
+    val label: Array<String> = [],
     @get:AliasFor(annotation = Transactional::class, attribute = "propagation")
     val propagation: Propagation = Propagation.REQUIRED,
     @get:AliasFor(annotation = Transactional::class, attribute = "isolation")
     val isolation: Isolation = Isolation.DEFAULT,
+    @get:AliasFor(annotation = Transactional::class, attribute = "timeout")
+    val timeout: Int = -1,
+    @get:AliasFor(annotation = Transactional::class, attribute = "timeoutString")
+    val timeoutString: String = "",
     @get:AliasFor(annotation = Transactional::class, attribute = "readOnly")
     val readOnly: Boolean = false,
+    @get:AliasFor(annotation = Transactional::class, attribute = "rollbackFor")
+    val rollbackFor: Array<KClass<out Throwable>> = [],
+    @get:AliasFor(annotation = Transactional::class, attribute = "rollbackForClassName")
+    val rollbackForClassName: Array<String> = [],
+    @get:AliasFor(annotation = Transactional::class, attribute = "noRollbackFor")
+    val noRollbackFor: Array<KClass<out Throwable>> = [],
+    @get:AliasFor(annotation = Transactional::class, attribute = "noRollbackForClassName")
+    val noRollbackForClassName: Array<String> = [],
 )

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/BrowseSubscriptionUseCase.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/BrowseSubscriptionUseCase.kt
@@ -3,7 +3,7 @@ package com.few.provider.usecase
 import com.few.provider.repository.SubscriptionRepository
 import com.few.provider.support.jpa.ProviderTransactional
 import com.few.provider.usecase.input.BrowseSubscriptionUseCaseIn
-import com.few.provider.usecase.out.EnrollSubscriptionUseCaseOut
+import com.few.provider.usecase.out.BrowseSubscriptionUseCaseOut
 import common.domain.Category
 import org.springframework.stereotype.Component
 
@@ -12,7 +12,7 @@ data class BrowseSubscriptionUseCase(
     private val subscriptionRepository: SubscriptionRepository,
 ) {
     @ProviderTransactional(readOnly = true)
-    fun execute(input: BrowseSubscriptionUseCaseIn): EnrollSubscriptionUseCaseOut {
+    fun execute(input: BrowseSubscriptionUseCaseIn): BrowseSubscriptionUseCaseOut {
         val existing = subscriptionRepository.findByEmail(input.email)
 
         return if (existing != null) {
@@ -24,9 +24,9 @@ data class BrowseSubscriptionUseCase(
                         Category.from(it.toInt())
                     }.toSet()
 
-            EnrollSubscriptionUseCaseOut(categories)
+            BrowseSubscriptionUseCaseOut(categories)
         } else {
-            EnrollSubscriptionUseCaseOut(emptySet())
+            BrowseSubscriptionUseCaseOut(emptySet())
         }
     }
 }

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/BrowseSubscriptionUseCase.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/BrowseSubscriptionUseCase.kt
@@ -1,0 +1,32 @@
+package com.few.provider.usecase
+
+import com.few.provider.repository.SubscriptionRepository
+import com.few.provider.support.jpa.ProviderTransactional
+import com.few.provider.usecase.input.BrowseSubscriptionUseCaseIn
+import com.few.provider.usecase.out.EnrollSubscriptionUseCaseOut
+import common.domain.Category
+import org.springframework.stereotype.Component
+
+@Component
+data class BrowseSubscriptionUseCase(
+    private val subscriptionRepository: SubscriptionRepository,
+) {
+    @ProviderTransactional(readOnly = true)
+    fun execute(input: BrowseSubscriptionUseCaseIn): EnrollSubscriptionUseCaseOut {
+        val existing = subscriptionRepository.findByEmail(input.email)
+
+        return if (existing != null) {
+            val categories =
+                existing.categories
+                    .split(",")
+                    .filter { it.isNotBlank() }
+                    .map {
+                        Category.from(it.toInt())
+                    }.toSet()
+
+            EnrollSubscriptionUseCaseOut(categories)
+        } else {
+            EnrollSubscriptionUseCaseOut(emptySet())
+        }
+    }
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
@@ -1,6 +1,8 @@
 package com.few.provider.usecase
 
 import com.few.provider.domain.Subscription
+import com.few.provider.domain.SubscriptionAction
+import com.few.provider.domain.SubscriptionHis
 import com.few.provider.repository.SubscriptionHisRepository
 import com.few.provider.repository.SubscriptionRepository
 import com.few.provider.support.jpa.ProviderTransactional
@@ -20,6 +22,14 @@ data class EnrollSubscriptionUseCase(
 
         val joinedCategories = input.categoryCodes.joinToString(",") { it.toString() }
         val categories = input.categoryCodes.map { Category.from(it) }.toSet()
+
+        subscriptionHisRepository.save(
+            SubscriptionHis(
+                email = input.email,
+                categories = joinedCategories,
+                action = SubscriptionAction.ENROLL.code,
+            ),
+        )
 
         return if (existing != null) {
             existing.categories = joinedCategories

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
@@ -1,8 +1,6 @@
 package com.few.provider.usecase
 
 import com.few.provider.domain.Subscription
-import com.few.provider.domain.SubscriptionAction
-import com.few.provider.domain.SubscriptionHis
 import com.few.provider.repository.SubscriptionHisRepository
 import com.few.provider.repository.SubscriptionRepository
 import com.few.provider.support.jpa.ProviderTransactional
@@ -18,90 +16,18 @@ data class EnrollSubscriptionUseCase(
 ) {
     @ProviderTransactional
     fun execute(input: EnrollSubscriptionUseCaseIn): EnrollSubscriptionUseCaseOut {
-        val requestedCategories = input.categoryCodes.map { code -> Category.from(code) }
+        val existing = subscriptionRepository.findByEmail(input.email)
 
-        // 기존 구독 정보 조회
-        val existingSubscription = subscriptionRepository.findByEmail(input.email)
+        val joinedCategories = input.categoryCodes.joinToString(",") { it.toString() }
+        val categories = input.categoryCodes.map { Category.from(it) }.toSet()
 
-        return if (existingSubscription != null) {
-            handleExistingSubscription(existingSubscription, requestedCategories)
+        return if (existing != null) {
+            existing.categories = joinedCategories
+            subscriptionRepository.save(existing)
+            EnrollSubscriptionUseCaseOut(categories)
         } else {
-            handleFirstSubscription(input.email, requestedCategories)
+            subscriptionRepository.save(Subscription(email = input.email, categories = joinedCategories))
+            EnrollSubscriptionUseCaseOut(categories)
         }
-    }
-
-    private fun handleExistingSubscription(
-        existingSubscription: Subscription,
-        requestedCategories: List<Category>,
-    ): EnrollSubscriptionUseCaseOut {
-        val existingCategories = mutableListOf<Category>()
-        val newCategories = mutableListOf<Category>()
-
-        // 현재 구독 중인 카테고리 파싱
-        val currentCategories =
-            existingSubscription.categories.split(",").filter { it.isNotBlank() }.map {
-                it.toInt()
-            }
-
-        requestedCategories.forEach { requestedCategory ->
-            if (currentCategories.contains(requestedCategory.code)) {
-                existingCategories.add(requestedCategory)
-            } else {
-                newCategories.add(requestedCategory)
-            }
-        }
-
-        // 신규 카테고리가 있는 경우 기존 구독 업데이트
-        if (newCategories.isNotEmpty()) {
-            val updatedCategories =
-                (currentCategories + newCategories.map { it.code }).joinToString(",")
-            existingSubscription.categories = updatedCategories
-            subscriptionRepository.save(existingSubscription)
-
-            // 신규 카테고리들을 SubscriptionHis에 한 번에 저장
-            val newCategoryCodes = newCategories.map { it.code }.joinToString(",")
-            subscriptionHisRepository.save(
-                SubscriptionHis(
-                    email = existingSubscription.email,
-                    categories = newCategoryCodes,
-                    action = SubscriptionAction.ENROLL.code,
-                ),
-            )
-        }
-
-        return EnrollSubscriptionUseCaseOut(
-            existingCategories = existingCategories,
-            newCategories = newCategories,
-        )
-    }
-
-    private fun handleFirstSubscription(
-        email: String,
-        requestedCategories: List<Category>,
-    ): EnrollSubscriptionUseCaseOut {
-        val categoryCodes = requestedCategories.map { it.code }
-        val categoriesString = categoryCodes.joinToString(",")
-
-        // Subscription 저장
-        subscriptionRepository.save(
-            Subscription(
-                email = email,
-                categories = categoriesString,
-            ),
-        )
-
-        // SubscriptionHis에 모든 카테고리를 한 번에 저장
-        subscriptionHisRepository.save(
-            SubscriptionHis(
-                email = email,
-                categories = categoriesString,
-                action = SubscriptionAction.ENROLL.code,
-            ),
-        )
-
-        return EnrollSubscriptionUseCaseOut(
-            existingCategories = emptyList(),
-            newCategories = requestedCategories,
-        )
     }
 }

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
@@ -20,15 +20,15 @@ data class EnrollSubscriptionUseCase(
     fun execute(input: EnrollSubscriptionUseCaseIn): EnrollSubscriptionUseCaseOut {
         val categories = input.categoryCodes.map { code -> Category.from(code) }
 
-        val existingCategories = mutableListOf<Int>()
-        val newCategories = mutableListOf<Int>()
+        val existingCategories = mutableListOf<Category>()
+        val newCategories = mutableListOf<Category>()
 
         categories.forEach { category ->
             val existingSubscription =
                 subscriptionRepository.findByEmailAndCategory(input.email, category.code)
 
             if (existingSubscription != null) {
-                existingCategories.add(category.code)
+                existingCategories.add(Category.from(category.code))
             } else {
                 subscriptionRepository.save(
                     Subscription(
@@ -45,7 +45,7 @@ data class EnrollSubscriptionUseCase(
                     ),
                 )
 
-                newCategories.add(category.code)
+                newCategories.add(Category.from(category.code))
             }
         }
 

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
@@ -1,0 +1,57 @@
+package com.few.provider.usecase
+
+import com.few.provider.domain.Subscription
+import com.few.provider.domain.SubscriptionAction
+import com.few.provider.domain.SubscriptionHis
+import com.few.provider.repository.SubscriptionHisRepository
+import com.few.provider.repository.SubscriptionRepository
+import com.few.provider.support.jpa.ProviderTransactional
+import com.few.provider.usecase.input.EnrollSubscriptionUseCaseIn
+import com.few.provider.usecase.out.EnrollSubscriptionUseCaseOut
+import common.domain.Category
+import org.springframework.stereotype.Component
+
+@Component
+data class EnrollSubscriptionUseCase(
+    private val subscriptionRepository: SubscriptionRepository,
+    private val subscriptionHisRepository: SubscriptionHisRepository,
+) {
+    @ProviderTransactional
+    fun execute(input: EnrollSubscriptionUseCaseIn): EnrollSubscriptionUseCaseOut {
+        val categories = input.categoryCodes.map { code -> Category.from(code) }
+
+        val existingCategories = mutableListOf<Int>()
+        val newCategories = mutableListOf<Int>()
+
+        categories.forEach { category ->
+            val existingSubscription =
+                subscriptionRepository.findByEmailAndCategory(input.email, category.code)
+
+            if (existingSubscription != null) {
+                existingCategories.add(category.code)
+            } else {
+                subscriptionRepository.save(
+                    Subscription(
+                        email = input.email,
+                        category = category.code,
+                    ),
+                )
+
+                subscriptionHisRepository.save(
+                    SubscriptionHis(
+                        email = input.email,
+                        category = category.code,
+                        action = SubscriptionAction.ENROLL.code,
+                    ),
+                )
+
+                newCategories.add(category.code)
+            }
+        }
+
+        return EnrollSubscriptionUseCaseOut(
+            existingCategories = existingCategories,
+            newCategories = newCategories,
+        )
+    }
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
@@ -18,40 +18,90 @@ data class EnrollSubscriptionUseCase(
 ) {
     @ProviderTransactional
     fun execute(input: EnrollSubscriptionUseCaseIn): EnrollSubscriptionUseCaseOut {
-        val categories = input.categoryCodes.map { code -> Category.from(code) }
+        val requestedCategories = input.categoryCodes.map { code -> Category.from(code) }
 
+        // 기존 구독 정보 조회
+        val existingSubscription = subscriptionRepository.findByEmail(input.email)
+
+        return if (existingSubscription != null) {
+            handleExistingSubscription(existingSubscription, requestedCategories)
+        } else {
+            handleFirstSubscription(input.email, requestedCategories)
+        }
+    }
+
+    private fun handleExistingSubscription(
+        existingSubscription: Subscription,
+        requestedCategories: List<Category>,
+    ): EnrollSubscriptionUseCaseOut {
         val existingCategories = mutableListOf<Category>()
         val newCategories = mutableListOf<Category>()
 
-        categories.forEach { category ->
-            val existingSubscription =
-                subscriptionRepository.findByEmailAndCategory(input.email, category.code)
-
-            if (existingSubscription != null) {
-                existingCategories.add(Category.from(category.code))
-            } else {
-                subscriptionRepository.save(
-                    Subscription(
-                        email = input.email,
-                        category = category.code,
-                    ),
-                )
-
-                subscriptionHisRepository.save(
-                    SubscriptionHis(
-                        email = input.email,
-                        category = category.code,
-                        action = SubscriptionAction.ENROLL.code,
-                    ),
-                )
-
-                newCategories.add(Category.from(category.code))
+        // 현재 구독 중인 카테고리 파싱
+        val currentCategories =
+            existingSubscription.categories.split(",").filter { it.isNotBlank() }.map {
+                it.toInt()
             }
+
+        requestedCategories.forEach { requestedCategory ->
+            if (currentCategories.contains(requestedCategory.code)) {
+                existingCategories.add(requestedCategory)
+            } else {
+                newCategories.add(requestedCategory)
+            }
+        }
+
+        // 신규 카테고리가 있는 경우 기존 구독 업데이트
+        if (newCategories.isNotEmpty()) {
+            val updatedCategories =
+                (currentCategories + newCategories.map { it.code }).joinToString(",")
+            existingSubscription.categories = updatedCategories
+            subscriptionRepository.save(existingSubscription)
+
+            // 신규 카테고리들을 SubscriptionHis에 한 번에 저장
+            val newCategoryCodes = newCategories.map { it.code }.joinToString(",")
+            subscriptionHisRepository.save(
+                SubscriptionHis(
+                    email = existingSubscription.email,
+                    categories = newCategoryCodes,
+                    action = SubscriptionAction.ENROLL.code,
+                ),
+            )
         }
 
         return EnrollSubscriptionUseCaseOut(
             existingCategories = existingCategories,
             newCategories = newCategories,
+        )
+    }
+
+    private fun handleFirstSubscription(
+        email: String,
+        requestedCategories: List<Category>,
+    ): EnrollSubscriptionUseCaseOut {
+        val categoryCodes = requestedCategories.map { it.code }
+        val categoriesString = categoryCodes.joinToString(",")
+
+        // Subscription 저장
+        subscriptionRepository.save(
+            Subscription(
+                email = email,
+                categories = categoriesString,
+            ),
+        )
+
+        // SubscriptionHis에 모든 카테고리를 한 번에 저장
+        subscriptionHisRepository.save(
+            SubscriptionHis(
+                email = email,
+                categories = categoriesString,
+                action = SubscriptionAction.ENROLL.code,
+            ),
+        )
+
+        return EnrollSubscriptionUseCaseOut(
+            existingCategories = emptyList(),
+            newCategories = requestedCategories,
         )
     }
 }

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/EnrollSubscriptionUseCase.kt
@@ -7,7 +7,7 @@ import com.few.provider.repository.SubscriptionHisRepository
 import com.few.provider.repository.SubscriptionRepository
 import com.few.provider.support.jpa.ProviderTransactional
 import com.few.provider.usecase.input.EnrollSubscriptionUseCaseIn
-import com.few.provider.usecase.out.EnrollSubscriptionUseCaseOut
+import com.few.provider.usecase.out.BrowseSubscriptionUseCaseOut
 import common.domain.Category
 import org.springframework.stereotype.Component
 
@@ -17,7 +17,7 @@ data class EnrollSubscriptionUseCase(
     private val subscriptionHisRepository: SubscriptionHisRepository,
 ) {
     @ProviderTransactional
-    fun execute(input: EnrollSubscriptionUseCaseIn): EnrollSubscriptionUseCaseOut {
+    fun execute(input: EnrollSubscriptionUseCaseIn): BrowseSubscriptionUseCaseOut {
         val existing = subscriptionRepository.findByEmail(input.email)
 
         val joinedCategories = input.categoryCodes.joinToString(",") { it.toString() }
@@ -34,10 +34,10 @@ data class EnrollSubscriptionUseCase(
         return if (existing != null) {
             existing.categories = joinedCategories
             subscriptionRepository.save(existing)
-            EnrollSubscriptionUseCaseOut(categories)
+            BrowseSubscriptionUseCaseOut(categories)
         } else {
             subscriptionRepository.save(Subscription(email = input.email, categories = joinedCategories))
-            EnrollSubscriptionUseCaseOut(categories)
+            BrowseSubscriptionUseCaseOut(categories)
         }
     }
 }

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/input/BrowseSubscriptionUseCaseIn.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/input/BrowseSubscriptionUseCaseIn.kt
@@ -1,0 +1,5 @@
+package com.few.provider.usecase.input
+
+data class BrowseSubscriptionUseCaseIn(
+    val email: String,
+)

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/input/EnrollSubscriptionUseCaseIn.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/input/EnrollSubscriptionUseCaseIn.kt
@@ -1,0 +1,6 @@
+package com.few.provider.usecase.input
+
+data class EnrollSubscriptionUseCaseIn(
+    val email: String,
+    val categoryCodes: List<Int>,
+)

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/out/BrowseSubscriptionUseCaseOut.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/out/BrowseSubscriptionUseCaseOut.kt
@@ -2,6 +2,6 @@ package com.few.provider.usecase.out
 
 import common.domain.Category
 
-data class EnrollSubscriptionUseCaseOut(
+data class BrowseSubscriptionUseCaseOut(
     val subscribedCategories: Set<Category>,
 )

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/out/EnrollSubscriptionUseCaseOut.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/out/EnrollSubscriptionUseCaseOut.kt
@@ -1,6 +1,8 @@
 package com.few.provider.usecase.out
 
+import common.domain.Category
+
 data class EnrollSubscriptionUseCaseOut(
-    val existingCategories: List<Int>,
-    val newCategories: List<Int>,
+    val existingCategories: List<Category>,
+    val newCategories: List<Category>,
 )

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/out/EnrollSubscriptionUseCaseOut.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/out/EnrollSubscriptionUseCaseOut.kt
@@ -1,0 +1,6 @@
+package com.few.provider.usecase.out
+
+data class EnrollSubscriptionUseCaseOut(
+    val existingCategories: List<Int>,
+    val newCategories: List<Int>,
+)

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/out/EnrollSubscriptionUseCaseOut.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/out/EnrollSubscriptionUseCaseOut.kt
@@ -3,6 +3,5 @@ package com.few.provider.usecase.out
 import common.domain.Category
 
 data class EnrollSubscriptionUseCaseOut(
-    val existingCategories: List<Category>,
-    val newCategories: List<Category>,
+    val subscribedCategories: Set<Category>,
 )

--- a/domain/provider/src/main/resources/application-provider-local.yaml
+++ b/domain/provider/src/main/resources/application-provider-local.yaml
@@ -1,0 +1,13 @@
+spring:
+    provider:
+        datasource:
+            url: jdbc:mysql://localhost:13306/generator?allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&allowMultiQueries=true
+            username: root
+            password: root
+            driver-class-name: com.mysql.cj.jdbc.Driver
+        jpa:
+            hibernate:
+                ddl-auto: update
+            properties:
+                hibernate:
+                    format_sql: true

--- a/domain/provider/src/main/resources/application-provider-prd.yaml
+++ b/domain/provider/src/main/resources/application-provider-prd.yaml
@@ -1,0 +1,13 @@
+spring:
+    provider:
+        datasource:
+            url: ${DB_HOSTNAME}/generator?allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&allowMultiQueries=true
+            username: ${DB_USERNAME}
+            password: ${DB_PASSWORD}
+            driver-class-name: com.mysql.cj.jdbc.Driver
+        jpa:
+            hibernate:
+                ddl-auto: update
+            properties:
+                hibernate:
+                    format_sql: true

--- a/library/common/src/main/kotlin/common/domain/Category.kt
+++ b/library/common/src/main/kotlin/common/domain/Category.kt
@@ -1,6 +1,6 @@
-package com.few.generator.domain
+package common.domain
 
-import web.handler.exception.BadRequestException
+import common.exception.BadRequestException
 
 enum class Category(
     val code: Int,

--- a/library/common/src/main/kotlin/common/domain/ImageSuffix.kt
+++ b/library/common/src/main/kotlin/common/domain/ImageSuffix.kt
@@ -1,4 +1,4 @@
-package com.few.generator.domain
+package common.domain
 
 enum class ImageSuffix(
     val extension: String,

--- a/library/common/src/main/kotlin/common/domain/MediaType.kt
+++ b/library/common/src/main/kotlin/common/domain/MediaType.kt
@@ -1,6 +1,6 @@
-package com.few.generator.domain
+package common.domain
 
-import web.handler.exception.BadRequestException
+import common.exception.BadRequestException
 
 enum class MediaType(
     val code: Int,

--- a/library/common/src/main/kotlin/common/exception/BadRequestException.kt
+++ b/library/common/src/main/kotlin/common/exception/BadRequestException.kt
@@ -1,4 +1,4 @@
-package web.handler.exception
+package common.exception
 
 class BadRequestException(
     message: String,

--- a/library/web/build.gradle.kts
+++ b/library/web/build.gradle.kts
@@ -8,6 +8,7 @@ tasks.getByName("jar") {
 
 dependencies {
     api(project(":library:security"))
+    api(project(":library:common"))
 
     /** starter */
     api("org.springframework.boot:spring-boot-starter-web")

--- a/library/web/src/main/kotlin/web/filter/MDCLogFilter.kt
+++ b/library/web/src/main/kotlin/web/filter/MDCLogFilter.kt
@@ -7,6 +7,7 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.apache.commons.lang3.RandomStringUtils
 import org.slf4j.MDC
 import org.springframework.http.HttpHeaders
@@ -23,6 +24,10 @@ class MDCLogFilter(
     ) {
         val requestStartTime = System.currentTimeMillis()
         val traceId = RandomStringUtils.randomAlphanumeric(10)
+
+        val httpResponse = response as HttpServletResponse
+        httpResponse.setHeader("X-Trace-Id", traceId)
+
         MDC.put("Type", "Request MDC Info")
         MDC.put("RequestId", request!!.requestId)
         MDC.put("Request-Remote-Address", request.remoteAddr)

--- a/library/web/src/main/kotlin/web/handler/ControllerExceptionHandler.kt
+++ b/library/web/src/main/kotlin/web/handler/ControllerExceptionHandler.kt
@@ -1,5 +1,6 @@
 package web.handler
 
+import common.exception.BadRequestException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.ConstraintViolationException
 import org.springframework.beans.TypeMismatchException
@@ -16,7 +17,6 @@ import org.springframework.web.server.ServerWebInputException
 import web.ApiResponse
 import web.ApiResponseGenerator
 import web.ExceptionMessage
-import web.handler.exception.BadRequestException
 import java.nio.file.AccessDeniedException
 
 @RestControllerAdvice

--- a/library/web/src/main/kotlin/web/security/config/LocalDelegatedSecurityConfigurer.kt
+++ b/library/web/src/main/kotlin/web/security/config/LocalDelegatedSecurityConfigurer.kt
@@ -114,6 +114,10 @@ class LocalDelegatedSecurityConfigurer(
                     AntPathRequestMatcher("/api/v1/contents"),
                     AntPathRequestMatcher("/api/v1/contents/**"),
                     AntPathRequestMatcher("/api/v1/rawcontents/**"),
+                    /**
+                     * provider
+                     */
+                    AntPathRequestMatcher("/api/v1/subscriptions"),
                 )
         }
 

--- a/library/web/src/main/kotlin/web/security/config/ProdDelegatedSecurityConfigurer.kt
+++ b/library/web/src/main/kotlin/web/security/config/ProdDelegatedSecurityConfigurer.kt
@@ -117,6 +117,10 @@ class ProdDelegatedSecurityConfigurer(
                     AntPathRequestMatcher("/api/v1/contents"),
                     AntPathRequestMatcher("/api/v1/contents/**"),
                     AntPathRequestMatcher("/api/v1/rawcontents/**"),
+                    /**
+                     * provider
+                     */
+                    AntPathRequestMatcher("/api/v1/subscriptions"),
                 )
         }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include("api")
 
 include("domain")
 include("domain:generator")
+include("domain:provider")
 
 include("library")
 include("library:common")


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #716 

💁‍♂️ PR 내용
----
- 신규 도메인 모듈 추가: provider
- 이메일 구독 갱신 및 구독 조회 API 추가 (구독 대상은 '카테고리'임)
    - 구독 갱신: POST /api/v1/subscriptions 
        - 구독 상태를 아에 업데이트해버림(기존 구독상태 덮어씌움)
    - 구독 조회: GET /api/v1/subscriptions
        - 현재 구독중인 카테고리 조회
- 해당 작업 머지 후 구동한 정보(subscription테이블)를 기준으로 오전8시 이메일 발송 작업 진행 예정

🙏 작업
----

🙈 PR 참고 사항
----
- email에 대한 auth 작업 추후 필요
- 테스트 코드 작성 필요

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 구독(Subscription) API가 추가되어 사용자가 이메일과 카테고리 코드로 구독을 등록하고 조회할 수 있습니다.
  * 구독 관련 엔티티, JPA 설정, 데이터소스, Gson, 트랜잭션, 리포지토리, 유스케이스 등 provider 모듈 신규 도입.
  * 구독 요청/응답 모델 및 구독 히스토리 관리 기능이 포함되었습니다.
  * 구독 API 경로(/api/v1/subscriptions)가 인증 없이 접근 가능하도록 보안 설정이 추가되었습니다.
  * 응답 헤더에 X-Trace-Id가 추가되어 추적성이 강화되었습니다.

* **Chores**
  * 공통 도메인 및 예외 패키지 구조 정리와 의존성 개선이 이루어졌습니다.
  * Gradle 설정 및 환경별 application yaml 파일이 추가되었습니다.
  * 신규 provider 모듈 프로젝트 구조가 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->