### PR TITLE
[Feat/#725] 구독 취소하기 신규 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ storage/**/*.sql
 
 # build files
 **/target/
+
+# Claude Code local settings
+.claude/

--- a/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/controller/SubscriptionController.kt
@@ -5,8 +5,10 @@ import com.few.provider.controller.response.BrowseSubscriptionResponse
 import com.few.provider.controller.response.CodeValueResponse
 import com.few.provider.usecase.BrowseSubscriptionUseCase
 import com.few.provider.usecase.EnrollSubscriptionUseCase
+import com.few.provider.usecase.UnsubscribeUseCase
 import com.few.provider.usecase.input.BrowseSubscriptionUseCaseIn
 import com.few.provider.usecase.input.EnrollSubscriptionUseCaseIn
+import com.few.provider.usecase.input.UnsubscribeUseCaseIn
 import com.few.web.ApiResponse
 import com.few.web.ApiResponseGenerator
 import org.springframework.http.HttpStatus
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*
 class SubscriptionController(
     private val enrollSubscriptionUseCase: EnrollSubscriptionUseCase,
     private val browseSubscriptionUseCase: BrowseSubscriptionUseCase,
+    private val unsubscribeUseCase: UnsubscribeUseCase,
 ) {
     @PostMapping("/subscriptions")
     fun enrollSubscription(
@@ -56,6 +59,20 @@ class SubscriptionController(
                 ucOuts.subscribedCategories.map { CodeValueResponse(it.code, it.title) },
             ),
             HttpStatus.OK,
+        )
+    }
+
+    @DeleteMapping("/subscriptions")
+    fun unsubscribe(
+        @RequestHeader("email") email: String, // TODO: auth 적용
+    ): ApiResponse<ApiResponse.SuccessBody<Unit>> {
+        unsubscribeUseCase.execute(
+            UnsubscribeUseCaseIn(email),
+        )
+
+        return ApiResponseGenerator.success(
+            Unit,
+            HttpStatus.NO_CONTENT,
         )
     }
 }

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/UnsubscribeUseCase.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/UnsubscribeUseCase.kt
@@ -1,0 +1,32 @@
+package com.few.provider.usecase
+
+import com.few.common.exception.BadRequestException
+import com.few.provider.domain.SubscriptionAction
+import com.few.provider.domain.SubscriptionHis
+import com.few.provider.repository.SubscriptionHisRepository
+import com.few.provider.repository.SubscriptionRepository
+import com.few.provider.support.jpa.ProviderTransactional
+import com.few.provider.usecase.input.UnsubscribeUseCaseIn
+import org.springframework.stereotype.Component
+
+@Component
+data class UnsubscribeUseCase(
+    private val subscriptionRepository: SubscriptionRepository,
+    private val subscriptionHisRepository: SubscriptionHisRepository,
+) {
+    @ProviderTransactional
+    fun execute(input: UnsubscribeUseCaseIn) {
+        val existing =
+            subscriptionRepository.findByEmail(input.email)
+                ?: throw BadRequestException("구독하지 않은 이메일입니다.")
+
+        subscriptionHisRepository.save(
+            SubscriptionHis(
+                email = input.email,
+                categories = existing.categories,
+                action = SubscriptionAction.CANCEL.code,
+            ),
+        )
+        subscriptionRepository.delete(existing)
+    }
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/usecase/input/UnsubscribeUseCaseIn.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/usecase/input/UnsubscribeUseCaseIn.kt
@@ -1,0 +1,5 @@
+package com.few.provider.usecase.input
+
+data class UnsubscribeUseCaseIn(
+    val email: String,
+)


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #725 

💁‍♂️ PR 내용
----
- DELETE /api/v1/subscriptions 엔드포인트 추가
- 구독하지 않은 이메일에 대한 에러 처리 추가
- .gitignore에 .claude/ 디렉토리 추가
🤖 Generated with [Claude Code](https://claude.ai/code)

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 구독 취소 기능이 추가되어, 사용자가 이메일을 통해 구독을 직접 취소할 수 있습니다.

* **기타**
  * `.claude/` 디렉터리가 Git 버전 관리에서 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->