### PR TITLE
[Config/#737] Provider Swagger 추가

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorSwaggerConfig.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorSwaggerConfig.kt
@@ -1,0 +1,21 @@
+package com.few.generator.config
+
+import com.few.generator.config.GeneratorConfig.Companion.BEAN_NAME_PREFIX
+import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class GeneratorSwaggerConfig {
+    companion object {
+        const val OPEN_API_BEAN_NAME = BEAN_NAME_PREFIX + "OpenApi"
+    }
+
+    @Bean(name = [OPEN_API_BEAN_NAME])
+    fun generatorApi(): GroupedOpenApi =
+        GroupedOpenApi
+            .builder()
+            .group("Generator API")
+            .packagesToScan(GeneratorConfig.BASE_PACKAGE)
+            .build()
+}

--- a/domain/provider/src/main/kotlin/com/few/provider/config/ProviderSwaggerConfig.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/config/ProviderSwaggerConfig.kt
@@ -1,21 +1,21 @@
-package com.few.generator.config
+package com.few.provider.config
 
-import com.few.generator.config.GeneratorConfig.Companion.BEAN_NAME_PREFIX
+import com.few.provider.config.ProviderConfig.Companion.BEAN_NAME_PREFIX
 import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class GeneratorOpenApiConfig {
+class ProviderSwaggerConfig {
     companion object {
         const val OPEN_API_BEAN_NAME = BEAN_NAME_PREFIX + "OpenApi"
     }
 
     @Bean(name = [OPEN_API_BEAN_NAME])
-    fun generatorApi(): GroupedOpenApi =
+    fun providerApi(): GroupedOpenApi =
         GroupedOpenApi
             .builder()
-            .group("Generator API")
-            .packagesToScan(GeneratorConfig.BASE_PACKAGE)
+            .group("Provider API")
+            .packagesToScan(ProviderConfig.BASE_PACKAGE)
             .build()
 }

--- a/library/common/src/main/kotlin/com/few/common/config/SwaggerConfig.kt
+++ b/library/common/src/main/kotlin/com/few/common/config/SwaggerConfig.kt
@@ -26,7 +26,6 @@ class SwaggerConfig(
             .security(listOf(securityRequirement))
             .addServersItem(Server().url("http://localhost:8080"))
             .addServersItem(Server().url("https://api.fewletter.store"))
-            .addServersItem(Server().url("https://api.fewletter.shop"))
             .info(
                 Info()
                     .version("2.0.0")


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #737 

💁‍♂️ PR 내용
----

🙏 작업
----
- GeneratorOpenApiConfig -> GeneratorSwaggerConfig 파일명 변경
- ProviderSwaggerConfig 신규 추가
- SwaggerConfig 공통 설정 개선

🤖 Generated with [Claude Code](https://claude.ai/code)


🙈 PR 참고 사항
----

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Swagger UI에 Provider API 그룹이 추가되어 도메인별 문서를 쉽게 탐색할 수 있습니다.
- Documentation
  - Swagger/OpenAPI 서버 목록을 업데이트했습니다: localhost와 https://api.fewletter.store만 노출되며 .shop 도메인은 제거되었습니다.
- Refactor
  - 설정 클래스 명칭을 정리했습니다. 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->