### PR TITLE
[Config/#742] JDBC 타임아웃 및 HikariCP 커넥션 풀 설정 조정

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorDataSourceConfig.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorDataSourceConfig.kt
@@ -26,11 +26,12 @@ class GeneratorDataSourceConfig {
                 password = dataSourceProperties.password
                 driverClassName = dataSourceProperties.driverClassName
                 poolName = "Generator-POOL"
-                maximumPoolSize = 16
-                minimumIdle = 4
-                connectionTimeout = 30000
+                maximumPoolSize = 8
+                minimumIdle = 8
+                connectionTimeout = 15000
                 idleTimeout = 300000
                 maxLifetime = 1800000
+                leakDetectionThreshold = 2000
                 connectionTestQuery = "SELECT 1"
             }
         return HikariDataSource(hikariConfig)

--- a/domain/generator/src/main/resources/application-generator-local.yaml
+++ b/domain/generator/src/main/resources/application-generator-local.yaml
@@ -19,7 +19,7 @@ spring:
                         decoder: com.few.generator.config.feign.OpenAiDecoder
     generator:
         datasource:
-            url: jdbc:mysql://localhost:13306/generator?allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&allowMultiQueries=true
+            url: jdbc:mysql://localhost:13306/generator?allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&allowMultiQueries=true&connectTimeout=10000&socketTimeout=1800000
             username: root
             password: root
             driver-class-name: com.mysql.cj.jdbc.Driver

--- a/domain/generator/src/main/resources/application-generator-prd.yaml
+++ b/domain/generator/src/main/resources/application-generator-prd.yaml
@@ -19,7 +19,7 @@ spring:
                         decoder: com.few.generator.config.feign.OpenAiDecoder
     generator:
         datasource:
-            url: ${DB_HOSTNAME}/generator?allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&allowMultiQueries=true
+            url: ${DB_HOSTNAME}/generator?allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&allowMultiQueries=true&connectTimeout=10000&socketTimeout=1800000
             username: ${DB_USERNAME}
             password: ${DB_PASSWORD}
             driver-class-name: com.mysql.cj.jdbc.Driver

--- a/domain/provider/src/main/kotlin/com/few/provider/config/ProviderDataSourceConfig.kt
+++ b/domain/provider/src/main/kotlin/com/few/provider/config/ProviderDataSourceConfig.kt
@@ -26,11 +26,12 @@ class ProviderDataSourceConfig {
                 password = dataSourceProperties.password
                 driverClassName = dataSourceProperties.driverClassName
                 poolName = "Provider-POOL"
-                maximumPoolSize = 16
-                minimumIdle = 4
-                connectionTimeout = 30000
+                maximumPoolSize = 8
+                minimumIdle = 8
+                connectionTimeout = 15000
                 idleTimeout = 300000
                 maxLifetime = 1800000
+                leakDetectionThreshold = 2000
                 connectionTestQuery = "SELECT 1"
             }
         return HikariDataSource(hikariConfig)

--- a/domain/provider/src/main/resources/application-provider-local.yaml
+++ b/domain/provider/src/main/resources/application-provider-local.yaml
@@ -1,7 +1,7 @@
 spring:
     provider:
         datasource:
-            url: jdbc:mysql://localhost:13306/generator?allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&allowMultiQueries=true
+            url: jdbc:mysql://localhost:13306/generator?allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&allowMultiQueries=true&connectTimeout=10000&socketTimeout=30000
             username: root
             password: root
             driver-class-name: com.mysql.cj.jdbc.Driver

--- a/domain/provider/src/main/resources/application-provider-prd.yaml
+++ b/domain/provider/src/main/resources/application-provider-prd.yaml
@@ -1,7 +1,7 @@
 spring:
     provider:
         datasource:
-            url: ${DB_HOSTNAME}/generator?allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&allowMultiQueries=true
+            url: ${DB_HOSTNAME}/generator?allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&allowMultiQueries=true&connectTimeout=10000&socketTimeout=30000
             username: ${DB_USERNAME}
             password: ${DB_PASSWORD}
             driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #742 

💁‍♂️ PR 내용
----
 ## generator
- 배치돌기 때문에 socketTimeout = 30분

## provider
- 단순 쿼리라 socketTimeout = 10분

cf. JDBC connectTimeout = 10초로 동일

## Example

### HikariCP config
```kotlin
    @Bean(name = [DATASOURCE])
    fun dataSource(
        @Qualifier(DATASOURCE_PROPERTIES) dataSourceProperties: DataSourceProperties,
    ): HikariDataSource {
        val hikariConfig =
            HikariConfig().apply {
                jdbcUrl = dataSourceProperties.url
                username = dataSourceProperties.username
                password = dataSourceProperties.password
                driverClassName = dataSourceProperties.driverClassName
                poolName = "Provider-POOL"
                maximumPoolSize = 8
                minimumIdle = 8
                connectionTimeout = 15000
                idleTimeout = 300000
                maxLifetime = 1800000
                leakDetectionThreshold = 2000
                connectionTestQuery = "SELECT 1"
            }
        return HikariDataSource(hikariConfig)
    }
```

### JDBC timeout config
```
connectTimeout=10000&socketTimeout=30000
```

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 데이터베이스 연결 풀 파라미터를 조정하고 누수 감지를 활성화하여 안정성과 자원 사용 효율을 개선했습니다.
  - 제너레이터/프로바이더 데이터소스에 접속 및 소켓 타임아웃을 명시해 지연 시 빠르게 실패하고 장기 작업의 안정성을 높였습니다.
  - 동일한 동작을 보장하도록 로컬과 운영 환경 설정을 정비해, 예외 상황에서의 응답성 향상과 예측 가능한 성능을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->