### PR TITLE
[Feat/#774] 구독 및 구독 취소시 Slack 알림 연계

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
@@ -4,9 +4,9 @@ import com.few.common.domain.Category
 import com.few.generator.controller.response.*
 import com.few.generator.service.GroupGenService
 import com.few.generator.usecase.BrowseContentsUseCase
+import com.few.generator.usecase.GenSchedulingUseCase
 import com.few.generator.usecase.GroupGenBrowseUseCase
 import com.few.generator.usecase.RawContentsBrowseContentUseCase
-import com.few.generator.usecase.SchedulingUseCase
 import com.few.generator.usecase.SendNewsletterUseCase
 import com.few.generator.usecase.input.BrowseContentsUseCaseIn
 import com.few.web.ApiResponse
@@ -23,7 +23,7 @@ import java.time.LocalDate
 @RestController
 @RequestMapping("/api/v1")
 class ContentsGeneratorController(
-    private val schedulingUseCase: SchedulingUseCase,
+    private val genSchedulingUseCase: GenSchedulingUseCase,
     private val newsletterSchedulingUseCase: SendNewsletterUseCase,
     private val rawContentsBrowseContentUseCase: RawContentsBrowseContentUseCase,
     private val browseContentsUseCase: BrowseContentsUseCase,
@@ -34,7 +34,7 @@ class ContentsGeneratorController(
         value = ["/contents/schedule"],
     )
     fun createAll(): ApiResponse<ApiResponse.Success> {
-        schedulingUseCase.execute()
+        genSchedulingUseCase.execute()
 
         return ApiResponseGenerator.success(
             HttpStatus.OK,

--- a/domain/generator/src/main/kotlin/com/few/generator/event/dto/EnrollSubscriptionEventDto.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/dto/EnrollSubscriptionEventDto.kt
@@ -1,0 +1,9 @@
+package com.few.generator.event.dto
+
+import java.time.LocalDateTime
+
+data class EnrollSubscriptionEventDto(
+    val email: String,
+    val categories: String,
+    val enrolledAt: LocalDateTime,
+)

--- a/domain/generator/src/main/kotlin/com/few/generator/event/dto/UnsubscribeEventDto.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/dto/UnsubscribeEventDto.kt
@@ -1,0 +1,9 @@
+package com.few.generator.event.dto
+
+import java.time.LocalDateTime
+
+data class UnsubscribeEventDto(
+    val email: String,
+    val categories: String,
+    val unsubscribedAt: LocalDateTime,
+)

--- a/domain/generator/src/main/kotlin/com/few/generator/event/handler/EnrollSubscriptionHandler.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/handler/EnrollSubscriptionHandler.kt
@@ -1,0 +1,55 @@
+package com.few.generator.event.handler
+
+import com.few.generator.event.dto.EnrollSubscriptionEventDto
+import com.few.web.client.Block
+import com.few.web.client.SlackBodyProperty
+import com.few.web.client.Text
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+@Component
+class EnrollSubscriptionHandler(
+    private val webhookRestTemplate: RestTemplate,
+    @Value("\${urls.webhook.slack}") private val webhookUrl: String,
+) {
+    private val log = KotlinLogging.logger {}
+
+    suspend fun handle(event: EnrollSubscriptionEventDto) {
+        val body =
+            SlackBodyProperty(
+                blocks =
+                    listOf(
+                        Block(
+                            type = "section",
+                            text = Text(text = "📧 *신규 구독*\n이메일: ${event.email}"),
+                        ),
+                        Block(
+                            type = "section",
+                            text = Text(text = "🏷️ *카테고리*\n${event.categories}"),
+                        ),
+                        Block(
+                            type = "section",
+                            text = Text(text = "⏰ *구독 시간*\n${event.enrolledAt}"),
+                        ),
+                    ),
+            )
+
+        webhookRestTemplate
+            .exchange(
+                webhookUrl,
+                HttpMethod.POST,
+                HttpEntity(body),
+                String::class.java,
+            ).let { res ->
+                if (res.statusCode.is2xxSuccessful) {
+                    log.info { "Webhook success: ${res.statusCode}" }
+                } else {
+                    log.error { "Webhook failed: ${res.statusCode}" }
+                }
+            }
+    }
+}

--- a/domain/generator/src/main/kotlin/com/few/generator/event/handler/UnsubscribeHandler.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/handler/UnsubscribeHandler.kt
@@ -1,0 +1,55 @@
+package com.few.generator.event.handler
+
+import com.few.generator.event.dto.UnsubscribeEventDto
+import com.few.web.client.Block
+import com.few.web.client.SlackBodyProperty
+import com.few.web.client.Text
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+@Component
+class UnsubscribeHandler(
+    private val webhookRestTemplate: RestTemplate,
+    @Value("\${urls.webhook.slack}") private val webhookUrl: String,
+) {
+    private val log = KotlinLogging.logger {}
+
+    suspend fun handle(event: UnsubscribeEventDto) {
+        val body =
+            SlackBodyProperty(
+                blocks =
+                    listOf(
+                        Block(
+                            type = "section",
+                            text = Text(text = "📧 *구독 취소*\n이메일: ${event.email}"),
+                        ),
+                        Block(
+                            type = "section",
+                            text = Text(text = "🏷️ *카테고리*\n${event.categories}"),
+                        ),
+                        Block(
+                            type = "section",
+                            text = Text(text = "⏰ *취소 시간*\n${event.unsubscribedAt}"),
+                        ),
+                    ),
+            )
+
+        webhookRestTemplate
+            .exchange(
+                webhookUrl,
+                HttpMethod.POST,
+                HttpEntity(body),
+                String::class.java,
+            ).let { res ->
+                if (res.statusCode.is2xxSuccessful) {
+                    log.info { "Webhook success: ${res.statusCode}" }
+                } else {
+                    log.error { "Webhook failed: ${res.statusCode}" }
+                }
+            }
+    }
+}

--- a/domain/generator/src/main/kotlin/com/few/generator/event/listener/ContentsSchedulingEventListener.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/listener/ContentsSchedulingEventListener.kt
@@ -11,13 +11,13 @@ import org.springframework.stereotype.Component
 @Component
 class ContentsSchedulingEventListener(
     private val contentsSchedulingHandler: ContentsSchedulingHandler,
-    private val discordIoCoroutineScope: CoroutineScope,
+    private val notificationIoCoroutineScope: CoroutineScope,
 ) {
     private val log = KotlinLogging.logger {}
 
     @EventListener
     fun handleEvent(event: ContentsSchedulingEventDto) {
-        discordIoCoroutineScope.launch {
+        notificationIoCoroutineScope.launch {
             contentsSchedulingHandler.handle(event)
         }
     }

--- a/domain/generator/src/main/kotlin/com/few/generator/event/listener/EnrollSubscriptionEventListener.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/listener/EnrollSubscriptionEventListener.kt
@@ -1,0 +1,24 @@
+package com.few.generator.event.listener
+
+import com.few.generator.event.dto.EnrollSubscriptionEventDto
+import com.few.generator.event.handler.EnrollSubscriptionHandler
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class EnrollSubscriptionEventListener(
+    private val enrollSubscriptionHandler: EnrollSubscriptionHandler,
+    private val notificationIoCoroutineScope: CoroutineScope,
+) {
+    private val log = KotlinLogging.logger {}
+
+    @EventListener
+    fun handleEvent(event: EnrollSubscriptionEventDto) {
+        notificationIoCoroutineScope.launch {
+            enrollSubscriptionHandler.handle(event)
+        }
+    }
+}

--- a/domain/generator/src/main/kotlin/com/few/generator/event/listener/UnsubscribeEventListener.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/listener/UnsubscribeEventListener.kt
@@ -1,0 +1,24 @@
+package com.few.generator.event.listener
+
+import com.few.generator.event.dto.UnsubscribeEventDto
+import com.few.generator.event.handler.UnsubscribeHandler
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class UnsubscribeEventListener(
+    private val unsubscribeHandler: UnsubscribeHandler,
+    private val notificationIoCoroutineScope: CoroutineScope,
+) {
+    private val log = KotlinLogging.logger {}
+
+    @EventListener
+    fun handleEvent(event: UnsubscribeEventDto) {
+        notificationIoCoroutineScope.launch {
+            unsubscribeHandler.handle(event)
+        }
+    }
+}

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/EnrollSubscriptionUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/EnrollSubscriptionUseCase.kt
@@ -4,17 +4,21 @@ import com.few.common.domain.Category
 import com.few.generator.domain.Subscription
 import com.few.generator.domain.SubscriptionAction
 import com.few.generator.domain.SubscriptionHis
+import com.few.generator.event.dto.EnrollSubscriptionEventDto
 import com.few.generator.repository.SubscriptionHisRepository
 import com.few.generator.repository.SubscriptionRepository
 import com.few.generator.support.jpa.GeneratorTransactional
 import com.few.generator.usecase.input.EnrollSubscriptionUseCaseIn
 import com.few.generator.usecase.out.BrowseSubscriptionUseCaseOut
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
+import java.time.LocalDateTime
 
 @Component
 data class EnrollSubscriptionUseCase(
     private val subscriptionRepository: SubscriptionRepository,
     private val subscriptionHisRepository: SubscriptionHisRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     @GeneratorTransactional
     fun execute(input: EnrollSubscriptionUseCaseIn): BrowseSubscriptionUseCaseOut {
@@ -28,6 +32,14 @@ data class EnrollSubscriptionUseCase(
                 email = input.email,
                 categories = joinedCategories,
                 action = SubscriptionAction.ENROLL.code,
+            ),
+        )
+
+        applicationEventPublisher.publishEvent(
+            EnrollSubscriptionEventDto(
+                email = input.email,
+                categories = joinedCategories,
+                enrolledAt = LocalDateTime.now(),
             ),
         )
 

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/EnrollSubscriptionUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/EnrollSubscriptionUseCase.kt
@@ -38,7 +38,7 @@ data class EnrollSubscriptionUseCase(
         applicationEventPublisher.publishEvent(
             EnrollSubscriptionEventDto(
                 email = input.email,
-                categories = joinedCategories,
+                categories = categories.joinToString(", ") { it.title },
                 enrolledAt = LocalDateTime.now(),
             ),
         )

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/GenSchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/GenSchedulingUseCase.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.measureTimeMillis
 
 @Component
-class SchedulingUseCase(
+class GenSchedulingUseCase(
     private val rawContentsService: RawContentsService,
     private val provisioningService: ProvisioningService,
     private val genService: GenService,

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/UnsubscribeUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/UnsubscribeUseCase.kt
@@ -3,16 +3,20 @@ package com.few.generator.usecase
 import com.few.common.exception.BadRequestException
 import com.few.generator.domain.SubscriptionAction
 import com.few.generator.domain.SubscriptionHis
+import com.few.generator.event.dto.UnsubscribeEventDto
 import com.few.generator.repository.SubscriptionHisRepository
 import com.few.generator.repository.SubscriptionRepository
 import com.few.generator.support.jpa.GeneratorTransactional
 import com.few.generator.usecase.input.UnsubscribeUseCaseIn
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
+import java.time.LocalDateTime
 
 @Component
 data class UnsubscribeUseCase(
     private val subscriptionRepository: SubscriptionRepository,
     private val subscriptionHisRepository: SubscriptionHisRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     @GeneratorTransactional
     fun execute(input: UnsubscribeUseCaseIn) {
@@ -28,5 +32,13 @@ data class UnsubscribeUseCase(
             ),
         )
         subscriptionRepository.delete(existing)
+
+        applicationEventPublisher.publishEvent(
+            UnsubscribeEventDto(
+                email = input.email,
+                categories = existing.categories,
+                unsubscribedAt = LocalDateTime.now(),
+            ),
+        )
     }
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/UnsubscribeUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/UnsubscribeUseCase.kt
@@ -1,5 +1,6 @@
 package com.few.generator.usecase
 
+import com.few.common.domain.Category
 import com.few.common.exception.BadRequestException
 import com.few.generator.domain.SubscriptionAction
 import com.few.generator.domain.SubscriptionHis
@@ -36,7 +37,12 @@ data class UnsubscribeUseCase(
         applicationEventPublisher.publishEvent(
             UnsubscribeEventDto(
                 email = input.email,
-                categories = existing.categories,
+                categories =
+                    existing.categories
+                        .split(",")
+                        .mapNotNull { it.toIntOrNull() }
+                        .map { Category.from(it) }
+                        .joinToString(", ") { it.title },
                 unsubscribedAt = LocalDateTime.now(),
             ),
         )


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #774 

💁‍♂️ PR 내용
----
- 구독 및 구독 취소시 Slack 알림 연계
- 코루틴 기반 Slack HTTP 웹훅 호출

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
