### PR TITLE
[Feat/#783] 해외 뉴스 GEN 생성 스케줄링 추가 (1차)

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
@@ -37,7 +37,7 @@ class ContentsGeneratorController(
         value = ["/contents/schedule"],
     )
     fun createAll(
-        @Validated @RequestBody request: ContentsSchedulingRequest,
+        @Validated @RequestBody(required = false) request: ContentsSchedulingRequest,
     ): ApiResponse<ApiResponse.Success> {
         if ("global".equals(request.region, ignoreCase = true)) {
             globalGenSchedulingUseCase.execute()

--- a/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
@@ -4,6 +4,7 @@ import com.few.common.domain.Category
 import com.few.generator.controller.response.*
 import com.few.generator.usecase.BrowseContentsUseCase
 import com.few.generator.usecase.GenSchedulingUseCase
+import com.few.generator.usecase.GlobalGenSchedulingUseCase
 import com.few.generator.usecase.GroupGenBrowseUseCase
 import com.few.generator.usecase.GroupSchedulingUseCase
 import com.few.generator.usecase.RawContentsBrowseContentUseCase
@@ -24,17 +25,24 @@ import java.time.LocalDate
 @RequestMapping("/api/v1")
 class ContentsGeneratorController(
     private val genSchedulingUseCase: GenSchedulingUseCase,
+    private val globalGenSchedulingUseCase: GlobalGenSchedulingUseCase,
     private val newsletterSchedulingUseCase: SendNewsletterUseCase,
     private val rawContentsBrowseContentUseCase: RawContentsBrowseContentUseCase,
     private val browseContentsUseCase: BrowseContentsUseCase,
     private val groupGenBrowseUseCase: GroupGenBrowseUseCase,
     private val groupSchedulingUseCase: GroupSchedulingUseCase,
 ) {
-    @PostMapping(
+    @GetMapping(
         value = ["/contents/schedule"],
     )
-    fun createAll(): ApiResponse<ApiResponse.Success> {
-        genSchedulingUseCase.execute()
+    fun createAll(
+        @RequestParam(defaultValue = "local") region: String,
+    ): ApiResponse<ApiResponse.Success> {
+        if ("global".equals(region, ignoreCase = true)) {
+            globalGenSchedulingUseCase.execute()
+        } else {
+            genSchedulingUseCase.execute()
+        }
 
         return ApiResponseGenerator.success(
             HttpStatus.OK,

--- a/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
@@ -1,6 +1,7 @@
 package com.few.generator.controller
 
 import com.few.common.domain.Category
+import com.few.generator.controller.request.ContentsSchedulingRequest
 import com.few.generator.controller.response.*
 import com.few.generator.usecase.BrowseContentsUseCase
 import com.few.generator.usecase.GenSchedulingUseCase
@@ -32,13 +33,13 @@ class ContentsGeneratorController(
     private val groupGenBrowseUseCase: GroupGenBrowseUseCase,
     private val groupSchedulingUseCase: GroupSchedulingUseCase,
 ) {
-    @GetMapping(
+    @PostMapping(
         value = ["/contents/schedule"],
     )
     fun createAll(
-        @RequestParam(defaultValue = "local") region: String,
+        @Validated @RequestBody request: ContentsSchedulingRequest,
     ): ApiResponse<ApiResponse.Success> {
-        if ("global".equals(region, ignoreCase = true)) {
+        if ("global".equals(request.region, ignoreCase = true)) {
             globalGenSchedulingUseCase.execute()
         } else {
             genSchedulingUseCase.execute()

--- a/domain/generator/src/main/kotlin/com/few/generator/controller/request/ContentsSchedulingRequest.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/request/ContentsSchedulingRequest.kt
@@ -1,0 +1,5 @@
+package com.few.generator.controller.request
+
+data class ContentsSchedulingRequest(
+    val region: String,
+)

--- a/domain/generator/src/main/kotlin/com/few/generator/controller/request/ContentsSchedulingRequest.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/request/ContentsSchedulingRequest.kt
@@ -1,5 +1,11 @@
 package com.few.generator.controller.request
 
-data class ContentsSchedulingRequest(
-    val region: String,
-)
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class ContentsSchedulingRequest
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    constructor(
+        @JsonProperty("region")
+        val region: String?,
+    )

--- a/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/Scrapper.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/Scrapper.kt
@@ -1,6 +1,7 @@
 package com.few.generator.core.scrapper
 
 import com.few.common.domain.Category
+import com.few.generator.core.scrapper.cnbc.CnbcScrapper
 import com.few.generator.core.scrapper.naver.NaverScrapper
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Component
 @Component
 class Scrapper(
     private val naverScrapper: NaverScrapper,
+    private val cnbcScrapper: CnbcScrapper,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -18,13 +20,22 @@ class Scrapper(
                 naverScrapper.extractUrlsByCategory(rootUrl)
             }
 
+    fun extractUrlsByCategoriesForCnbc(): Map<Category, Set<String>> =
+        cnbcScrapper
+            .getRootUrlsByCategory(Category.entries)
+            .mapValues { (_, rootUrl) ->
+                cnbcScrapper.extractUrlsByCategory(rootUrl)
+            }
+
     fun scrape(url: String): ScrappedResult {
         Thread.sleep((1..5).random().toLong())
 
         if (url.contains("naver.com")) {
             return naverScrapper.scrape(url)
+        } else if (url.contains("cnbc.com")) {
+            return cnbcScrapper.scrape(url)
         } else {
-            throw RuntimeException("Only support naver.com yet")
+            throw RuntimeException("Only support naver.com and cnbc.com yet")
         }
     }
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/Scrapper.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/Scrapper.kt
@@ -1,6 +1,7 @@
 package com.few.generator.core.scrapper
 
 import com.few.common.domain.Category
+import com.few.common.domain.Region
 import com.few.generator.core.scrapper.cnbc.CnbcScrapper
 import com.few.generator.core.scrapper.naver.NaverScrapper
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -13,19 +14,21 @@ class Scrapper(
 ) {
     private val log = KotlinLogging.logger {}
 
-    fun extractUrlsByCategories(): Map<Category, Set<String>> =
-        naverScrapper
-            .getRootUrlsByCategory(Category.entries)
-            .mapValues { (_, rootUrl) ->
-                naverScrapper.extractUrlsByCategory(rootUrl)
-            }
-
-    fun extractUrlsByCategoriesForCnbc(): Map<Category, Set<String>> =
-        cnbcScrapper
-            .getRootUrlsByCategory(Category.entries)
-            .mapValues { (_, rootUrl) ->
-                cnbcScrapper.extractUrlsByCategory(rootUrl)
-            }
+    fun extractUrlsByCategories(region: Region): Map<Category, Set<String>> =
+        when (region) {
+            Region.LOCAL ->
+                naverScrapper
+                    .getRootUrlsByCategory(Category.entries)
+                    .mapValues { (_, rootUrl) ->
+                        naverScrapper.extractUrlsByCategory(rootUrl)
+                    }
+            Region.GLOBAL ->
+                cnbcScrapper
+                    .getRootUrlsByCategory(Category.entries)
+                    .mapValues { (_, rootUrl) ->
+                        cnbcScrapper.extractUrlsByCategory(rootUrl)
+                    }
+        }
 
     fun scrape(url: String): ScrappedResult {
         Thread.sleep((1..5).random().toLong())

--- a/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/cnbc/CnbcConstants.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/cnbc/CnbcConstants.kt
@@ -1,0 +1,14 @@
+package com.few.generator.core.scrapper.cnbc
+
+import com.few.common.domain.Category
+import com.few.common.domain.ImageSuffix
+
+object CnbcConstants {
+    val SUPPORT_IMAGE_SUFFIX = ImageSuffix.entries.map { it.extension.lowercase() }
+    val ROOT_URL_MAP: Map<Category, String> =
+        mapOf(
+            Category.ECONOMY to "https://www.cnbc.com/investing/",
+            Category.TECHNOLOGY to "https://www.cnbc.com/technology/",
+            Category.POLITICS to "https://www.cnbc.com/politics/",
+        )
+}

--- a/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/cnbc/CnbcExtractor.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/cnbc/CnbcExtractor.kt
@@ -1,0 +1,68 @@
+package com.few.generator.core.scrapper.cnbc
+
+import org.jsoup.nodes.Document
+import java.net.URI
+
+object CnbcExtractor {
+    object Text {
+        fun extractTitle(document: Document): String =
+            document.selectFirst("h1.ArticleHeader-headline")?.text()?.trim()
+                ?: document.selectFirst("h1")?.text()?.trim()
+                ?: throw RuntimeException("Title element not found")
+
+        fun extractContent(document: Document): List<String> {
+            val contentElement =
+                document.selectFirst("div.ArticleBody-articleBody")
+                    ?: document.selectFirst("div.group")
+                    ?: throw RuntimeException("Content element not found")
+
+            val blocks =
+                contentElement
+                    .select("p")
+                    .eachText()
+                    .map { it.replace("\u00A0", " ").trim() }
+                    .filter { it.isNotEmpty() }
+                    .filter { it.length >= 10 }
+
+            return blocks.distinct()
+        }
+    }
+
+    object Image {
+        fun extractContentImages(document: Document): List<String> {
+            val imageUrls = mutableSetOf<String>()
+
+            document.select("img").forEach { img ->
+                img.attr("src").takeIf { it.isNotBlank() && isValidImageUrl(it) }?.let { imageUrls.add(it) }
+                img.attr("data-src").takeIf { it.isNotBlank() && isValidImageUrl(it) }?.let { imageUrls.add(it) }
+                img.attr("data-original").takeIf { it.isNotBlank() && isValidImageUrl(it) }?.let { imageUrls.add(it) }
+
+                img.attr("srcset").split(",").forEach { srcsetEntry ->
+                    val url = srcsetEntry.trim().split(" ")[0]
+                    if (url.isNotBlank() && isValidImageUrl(url)) {
+                        imageUrls.add(url)
+                    }
+                }
+            }
+
+            return imageUrls
+                .filter { it.startsWith("http://") || it.startsWith("https://") }
+                .toList()
+        }
+
+        fun extractThumbnailImageUrl(document: Document): String? =
+            document
+                .selectFirst("meta[property=og:image]")
+                ?.attr("content")
+                ?.trim()
+                ?.takeIf { it.startsWith("https://") || it.startsWith("http://") }
+
+        private fun isValidImageUrl(url: String): Boolean =
+            try {
+                val uri = URI(url)
+                CnbcConstants.SUPPORT_IMAGE_SUFFIX.any { uri.path.lowercase().endsWith(it) }
+            } catch (_: Exception) {
+                false
+            }
+    }
+}

--- a/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/cnbc/CnbcScrapper.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/cnbc/CnbcScrapper.kt
@@ -30,15 +30,20 @@ class CnbcScrapper(
         val request = Request.Builder().url(rootUrl).build()
         val html = getHtml(request)
 
-        val yesterday = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
-        val datePrefix = "https://www.cnbc.com/$yesterday/"
+        val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd")
+        val datePrefixes =
+            listOf(
+                "https://www.cnbc.com/${LocalDate.now().format(formatter)}/",
+                "https://www.cnbc.com/${LocalDate.now().minusDays(1).format(formatter)}/",
+                "https://www.cnbc.com/${LocalDate.now().minusDays(2).format(formatter)}/",
+            )
 
         val extractedUrls =
             Jsoup
                 .parse(html)
                 .select("a[href]")
                 .mapNotNull { it.attr("href") }
-                .filter { it.startsWith(datePrefix) }
+                .filter { url -> datePrefixes.any { prefix -> url.startsWith(prefix) } }
                 .map { it.split("?")[0] }
                 .toSet()
 

--- a/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/cnbc/CnbcScrapper.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/scrapper/cnbc/CnbcScrapper.kt
@@ -1,0 +1,82 @@
+package com.few.generator.core.scrapper.cnbc
+
+import com.few.common.domain.Category
+import com.few.generator.core.scrapper.ScrappedResult
+import io.github.oshai.kotlinlogging.KotlinLogging
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Service
+class CnbcScrapper(
+    private val scrapperHttpClient: OkHttpClient,
+) {
+    private val log = KotlinLogging.logger { }
+
+    fun getRootUrlsByCategory(categories: List<Category>): Map<Category, String> =
+        categories
+            .filter { it in CnbcConstants.ROOT_URL_MAP }
+            .associateWith { CnbcConstants.ROOT_URL_MAP[it]!! }
+
+    fun extractUrlsByCategory(rootUrl: String): Set<String> {
+        Thread.sleep((1..5).random() * 1000L)
+
+        log.debug { "[CNBC Category] URLs 추출 시작: $rootUrl" }
+
+        val request = Request.Builder().url(rootUrl).build()
+        val html = getHtml(request)
+
+        val yesterday = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
+        val datePrefix = "https://www.cnbc.com/$yesterday/"
+
+        val extractedUrls =
+            Jsoup
+                .parse(html)
+                .select("a[href]")
+                .mapNotNull { it.attr("href") }
+                .filter { it.startsWith(datePrefix) }
+                .map { it.split("?")[0] }
+                .toSet()
+
+        if (extractedUrls.isEmpty()) {
+            throw RuntimeException("[CNBC Category] No matching URLs found in: $rootUrl")
+        }
+
+        log.info { "[CNBC Category] URL 추출 완료: $rootUrl -> ${extractedUrls.size}개 URL" }
+
+        return extractedUrls
+    }
+
+    fun scrape(url: String): ScrappedResult {
+        val request = Request.Builder().url(url).build()
+        val html = getHtml(request)
+
+        val document: Document = Jsoup.parse(html)
+
+        val extractTitle = CnbcExtractor.Text.extractTitle(document)
+        val extractContents = CnbcExtractor.Text.extractContent(document)
+        val extractImgs = CnbcExtractor.Image.extractContentImages(document)
+        val extractThumbnailImageUrl = CnbcExtractor.Image.extractThumbnailImageUrl(document)
+
+        return ScrappedResult(
+            sourceUrl = url,
+            title = extractTitle,
+            rawTexts = extractContents,
+            images = extractImgs,
+            thumbnailImageUrl = extractThumbnailImageUrl,
+        )
+    }
+
+    private fun getHtml(request: Request): String =
+        scrapperHttpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw RuntimeException("[CNBC] HTTP ${response.code} ${response.message} for URL: ${request.url}")
+            }
+            response.body?.string()
+                ?: throw RuntimeException("[CNBC] Empty response body for URL: ${request.url}")
+        }
+}

--- a/domain/generator/src/main/kotlin/com/few/generator/domain/Gen.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/domain/Gen.kt
@@ -13,7 +13,7 @@ import jakarta.persistence.*
                 columnList = "provisioning_contents_id",
                 unique = false,
             ),
-            Index(name = "idx_gen_2", columnList = "created_at DESC"),
+            Index(name = "idx_gen_2", columnList = "created_at, region DESC"),
             Index(name = "idx_gen_3", columnList = "category", unique = false),
         ],
 )
@@ -27,4 +27,5 @@ data class Gen( // TODO: DB컬럼 타입 변경 필요
     @Column(columnDefinition = "TEXT", nullable = false) val summary: String,
     @Column(columnDefinition = "TEXT", nullable = false) val highlightTexts: String = "[]",
     @Column(nullable = false) val category: Int,
+    @Column(nullable = true) val region: Int? = null,
 ) : BaseEntity()

--- a/domain/generator/src/main/kotlin/com/few/generator/domain/Gen.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/domain/Gen.kt
@@ -27,5 +27,5 @@ data class Gen( // TODO: DB컬럼 타입 변경 필요
     @Column(columnDefinition = "TEXT", nullable = false) val summary: String,
     @Column(columnDefinition = "TEXT", nullable = false) val highlightTexts: String = "[]",
     @Column(nullable = false) val category: Int,
-    @Column(nullable = true) val region: Int? = null,
+    @Column(nullable = true) val region: Int,
 ) : BaseEntity()

--- a/domain/generator/src/main/kotlin/com/few/generator/domain/ProvisioningContents.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/domain/ProvisioningContents.kt
@@ -24,5 +24,5 @@ data class ProvisioningContents( // TODO: DB컬럼 타입 변경 필요
     @Column(nullable = false)
     val category: Int,
     @Column(nullable = true)
-    val region: Int? = null,
+    val region: Int,
 ) : BaseEntity()

--- a/domain/generator/src/main/kotlin/com/few/generator/domain/ProvisioningContents.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/domain/ProvisioningContents.kt
@@ -23,4 +23,6 @@ data class ProvisioningContents( // TODO: DB컬럼 타입 변경 필요
     val coreTextsJson: String = "[]", // JSON 문자열로 저장
     @Column(nullable = false)
     val category: Int,
+    @Column(nullable = true)
+    val region: Int? = null,
 ) : BaseEntity()

--- a/domain/generator/src/main/kotlin/com/few/generator/domain/RawContents.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/domain/RawContents.kt
@@ -25,5 +25,5 @@ data class RawContents(
     @Column(nullable = false)
     val mediaType: Int,
     @Column(nullable = true)
-    val region: Int? = null,
+    val region: Int,
 ) : BaseEntity()

--- a/domain/generator/src/main/kotlin/com/few/generator/domain/RawContents.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/domain/RawContents.kt
@@ -24,4 +24,6 @@ data class RawContents(
     val category: Int,
     @Column(nullable = false)
     val mediaType: Int,
+    @Column(nullable = true)
+    val region: Int? = null,
 ) : BaseEntity()

--- a/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
@@ -40,6 +40,7 @@ interface GenRepository : JpaRepository<Gen, Long> {
         AND g.created_at < (
             SELECT created_at FROM gen WHERE id = :targetId
         )
+        AND g.region = :region
         ORDER BY g.created_at DESC
         LIMIT :limitSize
         """,
@@ -49,15 +50,17 @@ interface GenRepository : JpaRepository<Gen, Long> {
         @Param("targetId") targetId: Long,
         @Param("category") category: Int,
         @Param("limitSize") limitSize: Int,
+        @Param("region") region: Int? = null,
     ): List<Gen>
 
     @Query(
-        "SELECT * FROM gen WHERE category = :category ORDER BY created_at DESC LIMIT :limitSize",
+        "SELECT * FROM gen WHERE category = :category and region = :region ORDER BY created_at DESC LIMIT :limitSize",
         nativeQuery = true,
     )
     fun findFirstLimitByCategory(
         @Param("category") category: Int,
         @Param("limitSize") limitSize: Int,
+        @Param("region") region: Int? = null,
     ): List<Gen>
 
     fun findAllByCreatedAtBetweenAndCategory(

--- a/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/repository/GenRepository.kt
@@ -7,8 +7,6 @@ import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
 
 interface GenRepository : JpaRepository<Gen, Long> {
-    fun findByProvisioningContentsId(provisioningContentsId: Long): List<Gen>
-
     @Query(
         """
         SELECT g.* FROM gen g
@@ -50,7 +48,7 @@ interface GenRepository : JpaRepository<Gen, Long> {
         @Param("targetId") targetId: Long,
         @Param("category") category: Int,
         @Param("limitSize") limitSize: Int,
-        @Param("region") region: Int? = null,
+        @Param("region") region: Int,
     ): List<Gen>
 
     @Query(
@@ -60,7 +58,7 @@ interface GenRepository : JpaRepository<Gen, Long> {
     fun findFirstLimitByCategory(
         @Param("category") category: Int,
         @Param("limitSize") limitSize: Int,
-        @Param("region") region: Int? = null,
+        @Param("region") region: Int,
     ): List<Gen>
 
     fun findAllByCreatedAtBetweenAndCategory(

--- a/domain/generator/src/main/kotlin/com/few/generator/service/GenService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/GenService.kt
@@ -57,6 +57,7 @@ class GenService(
                 summary = summary.summary,
                 highlightTexts = gson.toJson(listOf(highlightText.highlightText)),
                 category = Category.from(provisioningContent.category).code,
+                region = provisioningContent.region,
             ),
         )
     }

--- a/domain/generator/src/main/kotlin/com/few/generator/service/ProvisioningService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/ProvisioningService.kt
@@ -42,6 +42,7 @@ class ProvisioningService(
                 bodyTextsJson = gson.toJson(bodyTexts.texts), // TODO: DB 저장 타입 등 정의, 수정 필요
                 coreTextsJson = gson.toJson(coreTexts.texts),
                 category = rawContents.category,
+                region = rawContents.region,
             ),
         )
     }

--- a/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
@@ -2,6 +2,7 @@ package com.few.generator.service
 
 import com.few.common.domain.Category
 import com.few.common.domain.MediaType
+import com.few.common.domain.Region
 import com.few.common.exception.BadRequestException
 import com.few.generator.config.GeneratorGsonConfig.Companion.GSON_BEAN_NAME
 import com.few.generator.core.scrapper.Scrapper
@@ -24,7 +25,7 @@ class RawContentsService(
     fun create(
         url: String,
         category: Category,
-        region: Int? = null,
+        region: Region,
     ): RawContents {
         val scrappedResult = scrapper.scrape(url)
 
@@ -41,7 +42,7 @@ class RawContentsService(
                 imageUrls = gson.toJson(scrappedResult.images),
                 category = category.code,
                 mediaType = MediaType.find(scrappedResult.sourceUrl).code,
-                region = region,
+                region = region.code,
             ),
         )
     }

--- a/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/service/RawContentsService.kt
@@ -24,6 +24,7 @@ class RawContentsService(
     fun create(
         url: String,
         category: Category,
+        region: Int? = null,
     ): RawContents {
         val scrappedResult = scrapper.scrape(url)
 
@@ -40,6 +41,7 @@ class RawContentsService(
                 imageUrls = gson.toJson(scrappedResult.images),
                 category = category.code,
                 mediaType = MediaType.find(scrappedResult.sourceUrl).code,
+                region = region,
             ),
         )
     }

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/BrowseContentsUseCase.kt
@@ -2,6 +2,7 @@ package com.few.generator.usecase
 
 import com.few.common.domain.Category
 import com.few.common.domain.MediaType
+import com.few.common.domain.Region
 import com.few.generator.config.GeneratorGsonConfig.Companion.GSON_BEAN_NAME
 import com.few.generator.repository.GenRepository
 import com.few.generator.repository.ProvisioningContentsRepository
@@ -35,9 +36,9 @@ data class BrowseContentsUseCase(
             when {
                 input.categoryCode != null -> {
                     if (input.prevGenId == -1L) {
-                        genRepository.findFirstLimitByCategory(input.categoryCode, pageSize)
+                        genRepository.findFirstLimitByCategory(input.categoryCode, pageSize, Region.LOCAL.code)
                     } else {
-                        genRepository.findNextLimitByCategory(input.prevGenId, input.categoryCode, pageSize)
+                        genRepository.findNextLimitByCategory(input.prevGenId, input.categoryCode, pageSize, Region.LOCAL.code)
                     }
                 }
                 else -> {

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/GenSchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/GenSchedulingUseCase.kt
@@ -1,5 +1,6 @@
 package com.few.generator.usecase
 
+import com.few.common.domain.Region
 import com.few.common.exception.BadRequestException
 import com.few.generator.core.scrapper.Scrapper
 import com.few.generator.event.dto.ContentsSchedulingEventDto
@@ -90,7 +91,7 @@ class GenSchedulingUseCase(
     }
 
     private fun create(): Pair<Int, Int> {
-        val urlsByCategories = scrapper.extractUrlsByCategories()
+        val urlsByCategories = scrapper.extractUrlsByCategories(Region.LOCAL)
 
         var successCnt = 0
         var failCnt = 0
@@ -100,7 +101,7 @@ class GenSchedulingUseCase(
 
             for (url in urls) {
                 try {
-                    val rawContent = rawContentsService.create(url, category)
+                    val rawContent = rawContentsService.create(url, category, Region.LOCAL)
                     val provisioningContent = provisioningService.create(rawContent)
                     genService.create(rawContent, provisioningContent)
 

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/GlobalGenSchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/GlobalGenSchedulingUseCase.kt
@@ -100,7 +100,7 @@ class GlobalGenSchedulingUseCase(
 
             for (url in urls) {
                 try {
-                    val rawContent = rawContentsService.create(url, category)
+                    val rawContent = rawContentsService.create(url, category, region = 1)
                     val provisioningContent = provisioningService.create(rawContent)
                     genService.create(rawContent, provisioningContent)
 

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/GlobalGenSchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/GlobalGenSchedulingUseCase.kt
@@ -1,0 +1,124 @@
+package com.few.generator.usecase
+
+import com.few.common.exception.BadRequestException
+import com.few.generator.core.scrapper.Scrapper
+import com.few.generator.event.dto.ContentsSchedulingEventDto
+import com.few.generator.service.GenService
+import com.few.generator.service.ProvisioningService
+import com.few.generator.service.RawContentsService
+import com.few.generator.support.jpa.GeneratorTransactional
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.system.measureTimeMillis
+
+@Component
+class GlobalGenSchedulingUseCase(
+    private val rawContentsService: RawContentsService,
+    private val provisioningService: ProvisioningService,
+    private val genService: GenService,
+    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val scrapper: Scrapper,
+    @Value("\${generator.contents.countByCategory}")
+    private val contentsCountByCategory: Int,
+) {
+    private val log = KotlinLogging.logger {}
+    private val isRunning = AtomicBoolean(false)
+
+    @Scheduled(cron = "\${scheduling.cron.global-gen}")
+    @GeneratorTransactional
+    fun execute() {
+        /** 0~15분 사이 랜덤으로 sleep 후 진행 **/
+        Thread.sleep((0..15).random().toLong() * 60 * 1000)
+
+        if (!isRunning.compareAndSet(false, true)) {
+            throw BadRequestException("Global contents scheduling is already running. Please try again later.")
+        }
+
+        try {
+            doExecute()
+        } finally {
+            isRunning.set(false)
+        }
+    }
+
+    private fun doExecute() {
+        val startTime = LocalDateTime.now()
+        var isSuccess = true
+        var creationTimeSec = 0.0
+        var exception: Throwable? = null
+        var result: Pair<Int, Int> = Pair(0, 0)
+
+        runCatching {
+            creationTimeSec =
+                measureTimeMillis {
+                    result = create()
+                }.msToSeconds()
+        }.onFailure { ex ->
+            isSuccess = false
+            log.error(ex) { "글로벌 콘텐츠 스케줄링 중 오류 발생" }
+            exception = ex
+        }.also {
+            log.info {
+                buildString {
+                    appendLine("✅ isSuccess: $isSuccess")
+                    appendLine("✅ 시작 시간: $startTime")
+                    appendLine("✅ 소요 시간: $creationTimeSec")
+                    appendLine("✅ message: ${exception?.cause?.message}")
+                    append("✅ result: 생성(${result.first}) / 스킵(${result.second})")
+                }
+            }
+
+            applicationEventPublisher.publishEvent(
+                ContentsSchedulingEventDto(
+                    isSuccess = isSuccess,
+                    startTime = startTime,
+                    totalTime = "%.3f".format(creationTimeSec),
+                    message = if (isSuccess) "None" else exception?.cause?.message ?: "Unknown error",
+                    result = if (isSuccess) "생성(${result.first}) / 스킵(${result.second})" else "None",
+                ),
+            )
+
+            if (!isSuccess) {
+                throw BadRequestException("글로벌 콘텐츠 스케줄링에 실패 : ${exception?.cause?.message}")
+            }
+        }
+    }
+
+    private fun create(): Pair<Int, Int> {
+        val urlsByCategories = scrapper.extractUrlsByCategoriesForCnbc()
+
+        var successCnt = 0
+        var failCnt = 0
+
+        urlsByCategories.forEach { (category, urls) ->
+            var successCntByCategory = 0
+
+            for (url in urls) {
+                try {
+                    val rawContent = rawContentsService.create(url, category)
+                    val provisioningContent = provisioningService.create(rawContent)
+                    genService.create(rawContent, provisioningContent)
+
+                    successCntByCategory++
+                    successCnt++
+
+                    if (successCntByCategory >= contentsCountByCategory) break
+                } catch (e: Exception) {
+                    failCnt++
+                    log.error(e) {
+                        "글로벌 콘텐츠 생성 중 오류 발생하여 Skip 처리. URL: $url, 카테고리: ${category.title}"
+                    }
+                }
+            }
+        }
+
+        return successCnt to failCnt
+    }
+
+    private fun Long.msToSeconds(): Double = this / 1000.0
+}

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/GlobalGenSchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/GlobalGenSchedulingUseCase.kt
@@ -1,5 +1,6 @@
 package com.few.generator.usecase
 
+import com.few.common.domain.Region
 import com.few.common.exception.BadRequestException
 import com.few.generator.core.scrapper.Scrapper
 import com.few.generator.event.dto.ContentsSchedulingEventDto
@@ -90,7 +91,7 @@ class GlobalGenSchedulingUseCase(
     }
 
     private fun create(): Pair<Int, Int> {
-        val urlsByCategories = scrapper.extractUrlsByCategoriesForCnbc()
+        val urlsByCategories = scrapper.extractUrlsByCategories(Region.GLOBAL)
 
         var successCnt = 0
         var failCnt = 0
@@ -100,7 +101,7 @@ class GlobalGenSchedulingUseCase(
 
             for (url in urls) {
                 try {
-                    val rawContent = rawContentsService.create(url, category, region = 1)
+                    val rawContent = rawContentsService.create(url, category, Region.GLOBAL)
                     val provisioningContent = provisioningService.create(rawContent)
                     genService.create(rawContent, provisioningContent)
 

--- a/domain/generator/src/main/resources/application-generator-local.yaml
+++ b/domain/generator/src/main/resources/application-generator-local.yaml
@@ -35,6 +35,7 @@ scheduling:
         generator: "0 0 4 * * *"
         group: "0 0 5 * * *"
         send: "0 0 9 * * *"
+        global-gen: "0 0 13 * * *"
 
 urls:
     webhook:

--- a/library/common/src/main/kotlin/com/few/common/domain/MediaType.kt
+++ b/library/common/src/main/kotlin/com/few/common/domain/MediaType.kt
@@ -7,6 +7,7 @@ enum class MediaType(
     val title: String,
     val keywords: List<String>,
 ) {
+    /** Local **/
     CHOSUN(1, "조선일보", listOf("chosun")),
     KHAN(2, "경향신문", listOf("khan")),
     SBS(3, "SBS", listOf("sbs")),
@@ -46,6 +47,9 @@ enum class MediaType(
     YONHAPNEWS(37, "연합뉴스", listOf("yonhapnews", "yna.co.kr")),
     MAEIL(38, "매일신문", listOf("imaeil.com")),
     JOSEILBO(39, "조세일보", listOf("joseilbo.com")),
+
+    /** Global **/
+    CNBC(40, "CNBC", listOf("cnbc.com")),
     ETC(0, "ETC", emptyList()),
 
     ;

--- a/library/common/src/main/kotlin/com/few/common/domain/Region.kt
+++ b/library/common/src/main/kotlin/com/few/common/domain/Region.kt
@@ -1,0 +1,14 @@
+package com.few.common.domain
+
+enum class Region(
+    val code: Int,
+) {
+    LOCAL(0),
+    GLOBAL(1),
+
+    ;
+
+    companion object {
+        fun from(code: Int): Region = entries.find { it.code == code } ?: LOCAL
+    }
+}


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #783 

💁‍♂️ PR 내용
----
- 매일 오후 1시(KST) CNBC에서 크롤링
- 카테고리: 정치, 경제, 기술

🙏 작업
----

🙈 PR 참고 사항
----
- JPA Entity를 따로 가져갈지, 컬럼으로 분리할지 구분 필요, 현재 구분자 없이 한 테이블임
- 운영계 작업 후 아래 쿼리 수행 필요

```sql
update raw_contents
set region = 0
;

update provisioning_contents
set region = 0
;

update gen
set region = 0
;
```

📸 스크린샷
----

🚩 추가된 SQL 운영계 실행계획
---

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CNBC 뉴스 소스 지원: CNBC 기사 수집 및 본문·이미지·썸네일 추출, 매체 분류(CNBC) 추가
  * 글로벌 자동 생성: 지역(region)에 따른 글로벌 전용 생성 흐름 및 이를 트리거하는 수동 실행 엔드포인트 추가

* **Changes**
  * 콘텐츠 스케줄 API가 요청 본문의 region을 받도록 변경(POST /contents/schedule)
  * 콘텐츠 생성/저장 흐름에 region 정보가 전파되어 저장 및 조회(필터링)에 활용됨

* **Chores**
  * 스케줄 항목 추가: 매일 13:00 글로벌 생성 실행 예약
<!-- end of auto-generated comment: release notes by coderabbit.ai -->