### PR TITLE
[Config/#758] HikariCP connectionTestQuery 설정 제거

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorDataSourceConfig.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorDataSourceConfig.kt
@@ -29,7 +29,6 @@ class GeneratorDataSourceConfig {
                 maximumPoolSize = 8
                 minimumIdle = 8
                 connectionTimeout = 15000
-                idleTimeout = 300000
                 maxLifetime = 1800000
                 leakDetectionThreshold = 2000
             }


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

🎫 연관 이슈
---
resolved #758 

💁‍♂️ PR 내용
----
- connectionTestQuery 설정하면 getConnection시 DB로 테스트 쿼리를 매번 날리게 되어 있어, 딜레이 발생함
- 단, 해당 설정이 Failover 테스트에선 유리할 것으로 판단되어 추후 개선 필요(현상황에선 당장은 불필요)

🙈 PR 참고 사항
----
- HikariCP docs: https://github.com/brettwooldridge/HikariCP

🚩 추가된 SQL 운영계 실행계획
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 작업(Chores)
  - 데이터베이스 커넥션 구성에서 불필요한 연결 검증 설정을 정리했습니다.
  - 일부 환경에서 초기 연결 시 검증 동작이 달라질 수 있습니다.
- 리팩터(Refactor)
  - 내부 연결 설정을 단순화해 구성 복잡도를 낮추고 유지보수성을 개선했습니다.
- 품질 개선
  - 사용자 기능 변화는 없으며, 실행 안정성 및 초기화 성능에 소폭 긍정적 영향이 기대됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->