### PR TITLE
[Refactor/#806] 로컬/글로벌 뉴스 엔드포인트 통합 및 URL 기반 region 판단

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/ContentsGeneratorController.kt
@@ -3,6 +3,7 @@ package com.few.generator.controller
 import com.few.common.domain.Category
 import com.few.common.domain.ContentsType
 import com.few.common.domain.Region
+import com.few.common.exception.BadRequestException
 import com.few.generator.controller.request.ContentsSchedulingRequest
 import com.few.generator.controller.response.*
 import com.few.generator.usecase.BrowseContentsUseCase
@@ -42,10 +43,10 @@ class ContentsGeneratorController(
     fun createAll(
         @Validated @RequestBody(required = false) request: ContentsSchedulingRequest,
     ): ApiResponse<ApiResponse.Success> {
-        if ("global".equals(request.region, ignoreCase = true)) {
-            globalGenSchedulingUseCase.execute()
-        } else {
-            genSchedulingUseCase.execute()
+        when (request.type.uppercase()) {
+            ContentsType.GLOBAL_NEWS.title.uppercase() -> globalGenSchedulingUseCase.execute()
+            ContentsType.LOCAL_NEWS.title.uppercase() -> genSchedulingUseCase.execute()
+            else -> throw BadRequestException("Invalid Contents Type: ${request.type}")
         }
 
         return ApiResponseGenerator.success(

--- a/domain/generator/src/main/kotlin/com/few/generator/controller/request/ContentsSchedulingRequest.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/request/ContentsSchedulingRequest.kt
@@ -6,6 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 data class ContentsSchedulingRequest
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     constructor(
-        @JsonProperty("region")
-        val region: String?,
+        @JsonProperty("type")
+        val type: String,
     )


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

🎫 연관 이슈
---
resolved #806 

💁‍♂️ PR 내용
----

🙈 PR 참고 사항
----

🚩 추가된 SQL 운영계 실행계획
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 요청 URL을 기반으로 로컬/글로벌 뉴스 지역을 자동 감지하여 적절한 콘텐츠 제공.
- 버그 수정
  - 글로벌 뉴스 경로에서 지역이 잘못 적용되던 문제 해결로 경로별 콘텐츠 반환 일치.
  - 스케줄링 요청의 JSON 필드가 "region"에서 필수 "type"으로 변경되어 입력 검증 강화.
- 리팩터링
  - 로컬/글로벌 분기 로직을 단일 흐름으로 통합해 응답 일관성 및 유지보수성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->