### PR TITLE
[Refactor/#907] @Scheduled를 UseCase에서 SchedulingController로 리펙토링

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/controller/SchedulingController.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/controller/SchedulingController.kt
@@ -2,6 +2,8 @@ package com.few.generator.controller
 
 import com.few.generator.usecase.GlobalGenSchedulingUseCase
 import com.few.generator.usecase.LocalGenSchedulingUseCase
+import com.few.generator.usecase.SendCacheMetricsSchedulingUseCase
+import com.few.generator.usecase.SendNewsletterSchedulingUseCase
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
@@ -9,6 +11,8 @@ import org.springframework.stereotype.Component
 class SchedulingController(
     private val localGenSchedulingUseCase: LocalGenSchedulingUseCase,
     private val globalGenSchedulingUseCase: GlobalGenSchedulingUseCase,
+    private val sendCacheMetricsSchedulingUseCase: SendCacheMetricsSchedulingUseCase,
+    private val sendNewsletterSchedulingUseCase: SendNewsletterSchedulingUseCase,
 ) {
     @Scheduled(cron = "\${scheduling.cron.local-gen}")
     fun createLocalNewsContents() {
@@ -18,5 +22,15 @@ class SchedulingController(
     @Scheduled(cron = "\${scheduling.cron.global-gen}")
     fun createGlobalNewsContents() {
         globalGenSchedulingUseCase.executeAsync()
+    }
+
+    @Scheduled(cron = "\${scheduling.cron.cache-metrics}", zone = "Asia/Seoul")
+    fun sendCacheMetrics() {
+        sendCacheMetricsSchedulingUseCase.sendCacheMetrics()
+    }
+
+    @Scheduled(cron = "\${scheduling.cron.email}", zone = "Asia/Seoul")
+    fun sendEmail() {
+        sendNewsletterSchedulingUseCase.send()
     }
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/SendCacheMetricsSchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/SendCacheMetricsSchedulingUseCase.kt
@@ -7,7 +7,6 @@ import com.few.web.client.Block
 import com.few.web.client.SlackBodyProperty
 import com.few.web.client.Text
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -27,8 +26,7 @@ class SendCacheMetricsSchedulingUseCase(
      * 참고: Micrometer의 cache metrics는 애플리케이션 시작 이후 누적 통계입니다.
      * 일별 통계를 원한다면 별도의 저장소에 이전 값을 저장하고 차이를 계산해야 합니다.
      */
-    @Scheduled(cron = "\${scheduling.cron.cache-metrics}", zone = "Asia/Seoul")
-    fun scheduledSendCacheMetrics() {
+    fun sendCacheMetrics() {
         if (!isRunning.compareAndSet(false, true)) {
             log.warn { "캐시 메트릭 전송이 이미 실행 중입니다." }
             return

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/SendNewsletterSchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/SendNewsletterSchedulingUseCase.kt
@@ -6,9 +6,7 @@ import com.few.generator.service.specifics.newsletter.NewsletterContentAggregato
 import com.few.generator.service.specifics.newsletter.NewsletterDelivery
 import com.few.generator.support.jpa.GeneratorTransactional
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.time.Clock
 import java.time.LocalDateTime
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.measureTimeMillis
@@ -18,14 +16,12 @@ class SendNewsletterSchedulingUseCase(
     private val genService: GenService,
     private val newsletterContentAggregator: NewsletterContentAggregator,
     private val newsletterDeliveryService: NewsletterDelivery,
-    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     private val log = KotlinLogging.logger {}
     private val isRunning = AtomicBoolean(false)
 
-    @Scheduled(cron = "\${scheduling.cron.email}", zone = "Asia/Seoul")
     @GeneratorTransactional
-    fun scheduledSend() {
+    fun send() {
         if (!isRunning.compareAndSet(false, true)) {
             log.warn { "뉴스레터 스케줄링이 이미 실행 중입니다." }
             return


### PR DESCRIPTION
- SendCacheMetricsSchedulingUseCase, SendNewsletterSchedulingUseCase에서 @Scheduled 제거
- SchedulingController에서 스케줄링 책임 통합 관리
- 불필요한 Clock 의존성 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🎫 연관 이슈
---
resolved #907 

💁‍♂️ PR 내용
----

🙈 PR 참고 사항
----

🚩 추가된 SQL 운영계 실행계획
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 스케줄링 시스템의 아키텍처를 개선하여 캐시 메트릭 전송과 뉴스레터 배포 프로세스를 보다 효율적으로 중앙 집중식으로 관리할 수 있도록 변경했습니다. 기존 기능은 정상 작동합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->