### PR TITLE
[FIx/#930] 인스타그램 해시태그 키워드에 공백이 포함되는 문제 수정

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/InstagramUploadUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/InstagramUploadUseCase.kt
@@ -131,7 +131,11 @@ class InstagramUploadUseCase(
             val keywords =
                 chatGpt.ask(prompt) as? Keywords
                     ?: throw IllegalStateException("ChatGPT 응답을 Keywords로 변환할 수 없습니다")
-            keywords.keywords.take(MAX_HASHTAGS_PER_CATEGORY)
+            /**
+             * 해시테그 내 공백 대체
+             * ex. "삼성 전자" -> "삼성전자"
+             */
+            keywords.keywords.map { it.replace(" ", "") }.take(MAX_HASHTAGS_PER_CATEGORY)
         } catch (e: Exception) {
             log.warn(e) { "GPT를 통한 동적 해시태그 생성 실패, 빈 해시태그로 대체합니다: ${e.message}" }
             emptyList()


### PR DESCRIPTION
프롬프트 방식 대신 코드상에서 키워드 공백 제거 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🎫 연관 이슈
---
resolved #930 

💁‍♂️ PR 내용
----

🙈 PR 참고 사항
----

🚩 추가된 SQL 운영계 실행계획
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Instagram 업로드 시 생성되는 해시태그의 공백 처리 개선으로 해시태그 품질 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->