### PR TITLE
[Fix/#934] maxGroupSize 9 -> 10 롤백

### DIFF
--- a/domain/generator/src/main/resources/application-generator-local.yaml
+++ b/domain/generator/src/main/resources/application-generator-local.yaml
@@ -67,7 +67,7 @@ generator:
     grouping:
         targetPercentage: 30
         minGroupSize: 3
-        maxGroupSize: 9
+        maxGroupSize: 10
         similarityThreshold: 0.7
     instagram:
         account-id: ${INSTAGRAM_ACCOUNT_ID}

--- a/domain/generator/src/main/resources/application-generator-prd.yaml
+++ b/domain/generator/src/main/resources/application-generator-prd.yaml
@@ -65,7 +65,7 @@ generator:
     grouping:
         targetPercentage: 30
         minGroupSize: 3
-        maxGroupSize: 9
+        maxGroupSize: 10
         similarityThreshold: 0.7
     instagram:
         account-id: ${INSTAGRAM_ACCOUNT_ID}


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #934 

💁‍♂️ PR 내용
----

🙈 PR 참고 사항
----

🚩 추가된 SQL 운영계 실행계획
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * 콘텐츠 그룹화 및 스크래핑 로직의 최대 그룹 크기 제한을 9에서 10으로 상향 조정했습니다. 이 설정 변경으로 그룹화 처리의 유연성이 증대되어 더 효율적인 콘텐츠 관리가 가능해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->