### PR TITLE
[Refactor/#967] Thread.sleep 부분 코루틴 delay Non-Blocking 적용

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorCoroutineConfig.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorCoroutineConfig.kt
@@ -1,12 +1,17 @@
 package com.few.generator.config
 
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 class GeneratorCoroutineConfig {
-    @Bean
-    fun discordIoCoroutineScope(): CoroutineScope = CoroutineScope(Dispatchers.IO.limitedParallelism(2))
+    @Bean(name = ["instagramCoroutineScope"])
+    fun instagramCoroutineScope(): CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob() + CoroutineName("instagram-coroutine"))
+
+    @Bean(name = ["groupGenCoroutineScope"])
+    fun groupGenCoroutineScope(): CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob() + CoroutineName("group-gen-coroutine"))
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorCoroutineConfig.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/config/GeneratorCoroutineConfig.kt
@@ -9,9 +9,28 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class GeneratorCoroutineConfig {
+    /**
+     * Instagram 업로드용 코루틴 스코프
+     *
+     * - [SupervisorJob]: 카테고리별 업로드가 독립적으로 실행되므로, 한 카테고리 실패가 다른 카테고리에 영향을 주지 않도록 격리
+     * - [Dispatchers.Default]: HTTP I/O는 OkHttp 내부 스레드풀(enqueue + suspendCancellableCoroutine)이 처리하며,
+     *   스코프의 스레드는 suspend delay 대기, 조건 체크 등 경량 작업만 수행하므로 IO 스레드풀 불필요
+     * - 이벤트 리스너에서 fire-and-forget으로 업로드 작업을 비동기 실행할 때 사용
+     */
     @Bean(name = ["instagramCoroutineScope"])
-    fun instagramCoroutineScope(): CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob() + CoroutineName("instagram-coroutine"))
+    fun instagramCoroutineScope(): CoroutineScope =
+        CoroutineScope(
+            Dispatchers.Default + SupervisorJob() + CoroutineName("instagram-coroutine"),
+        )
 
+    /**
+     * GroupGen 스케줄링용 코루틴 스코프
+     *
+     * - [SupervisorJob]: 카테고리별 GroupGen 생성이 독립적으로 실행되므로, 한 카테고리 실패가 다른 카테고리에 영향을 주지 않도록 격리
+     * - [Dispatchers.IO]: runBlocking(groupGenScope.coroutineContext) 내부에서 JPA 쿼리(블로킹 DB I/O)와
+     *   GPT API 호출(블로킹 HTTP I/O)이 발생하므로 IO 스레드풀 필요
+     * - 키워드 추출, 그룹화, 그룹 콘텐츠 생성 등 외부 I/O가 포함된 배치 처리 작업에 사용
+     */
     @Bean(name = ["groupGenCoroutineScope"])
     fun groupGenCoroutineScope(): CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob() + CoroutineName("group-gen-coroutine"))
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/core/instagram/InstagramUploader.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/instagram/InstagramUploader.kt
@@ -6,12 +6,13 @@ import com.few.generator.support.utils.DelayUtil
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import okhttp3.*
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import java.util.Random
 
 data class InstagramResponse(
     val id: String,
@@ -39,109 +40,115 @@ class InstagramUploader(
     private val gson: Gson,
 ) {
     private val log = KotlinLogging.logger {}
-    private val random = Random()
 
     // 1단계: 개별 이미지용 컨테이너 생성
-    fun createChildMediaContainer(imageUrl: String): String? {
-        val url =
-            "https://graph.instagram.com/$accountId/media"
-                .toHttpUrlOrNull()
-                ?.newBuilder()
-                ?.addQueryParameter("access_token", instagramTokenService.getLatestAccessToken())
-                ?.addQueryParameter("image_url", imageUrl)
-                ?.addQueryParameter("is_carousel_item", "true")
-                ?.build()
+    suspend fun createChildMediaContainer(imageUrl: String): String? =
+        withContext(Dispatchers.IO) {
+            val url =
+                "https://graph.instagram.com/$accountId/media"
+                    .toHttpUrlOrNull()
+                    ?.newBuilder()
+                    ?.addQueryParameter("access_token", instagramTokenService.getLatestAccessToken())
+                    ?.addQueryParameter("image_url", imageUrl)
+                    ?.addQueryParameter("is_carousel_item", "true")
+                    ?.build()
 
-        val request =
-            Request
-                .Builder()
-                .url(url!!)
-                .post(RequestBody.create(null, ""))
-                .build()
+            val request =
+                Request
+                    .Builder()
+                    .url(url!!)
+                    .post(RequestBody.create(null, ""))
+                    .build()
 
-        instagramOkHttpClient.newCall(request).execute().use { response ->
-            val responseBody = response.body?.string()
-            if (!response.isSuccessful) {
+            val (responseBody, isSuccessful, code) =
+                instagramOkHttpClient.newCall(request).execute().use { response ->
+                    Triple(response.body?.string(), response.isSuccessful, response.code)
+                }
+
+            if (!isSuccessful) {
                 val errorResponse = parseErrorResponse(responseBody)
-                logErrorResponse("[Step1] Child MediaContainer", response.code, errorResponse)
+                logErrorResponse("[Step1] Child MediaContainer", code, errorResponse)
                 throw RuntimeException(
                     "[Instagram][Step1] Creation of Child MediaContainer Failed: ${errorResponse?.error?.message ?: "Unknown error"}",
                 )
             }
-            // 5~10초 사이 랜덤 추출 TODO: 이미지 컨테이너 올라갔는지 폴링하도록 변경
-            DelayUtil.randomDelay(10, 15)
 
-            return responseBody?.let { parseJsonForId(it).id }
+            // TODO: 이미지 컨테이너 올라갔는지 폴링하도록 변경
+            DelayUtil.randomDelay(10, 15)
+            responseBody?.let { parseJsonForId(it).id }
         }
-    }
 
     // 2단계: 캐러셀용 부모 컨테이너 생성
-    fun createParentMediaContainer(
+    suspend fun createParentMediaContainer(
         imageUrls: List<String>,
         caption: String,
-    ): String? {
-        val url =
-            "https://graph.instagram.com/$accountId/media"
-                .toHttpUrlOrNull()
-                ?.newBuilder()
-                ?.addQueryParameter("access_token", instagramTokenService.getLatestAccessToken())
-                ?.addQueryParameter("children", imageUrls.joinToString(separator = ","))
-                ?.addQueryParameter("caption", caption)
-                ?.addQueryParameter("media_type", "CAROUSEL")
-                ?.build()
+    ): String? =
+        withContext(Dispatchers.IO) {
+            val url =
+                "https://graph.instagram.com/$accountId/media"
+                    .toHttpUrlOrNull()
+                    ?.newBuilder()
+                    ?.addQueryParameter("access_token", instagramTokenService.getLatestAccessToken())
+                    ?.addQueryParameter("children", imageUrls.joinToString(separator = ","))
+                    ?.addQueryParameter("caption", caption)
+                    ?.addQueryParameter("media_type", "CAROUSEL")
+                    ?.build()
 
-        val request =
-            Request
-                .Builder()
-                .url(url!!)
-                .post(RequestBody.create(null, ""))
-                .build()
+            val request =
+                Request
+                    .Builder()
+                    .url(url!!)
+                    .post(RequestBody.create(null, ""))
+                    .build()
 
-        instagramOkHttpClient.newCall(request).execute().use { response ->
-            val responseBody = response.body?.string()
-            if (!response.isSuccessful) {
+            val (responseBody, isSuccessful, code) =
+                instagramOkHttpClient.newCall(request).execute().use { response ->
+                    Triple(response.body?.string(), response.isSuccessful, response.code)
+                }
+
+            if (!isSuccessful) {
                 val errorResponse = parseErrorResponse(responseBody)
-                logErrorResponse("[Step2] Parent MediaContainer", response.code, errorResponse)
+                logErrorResponse("[Step2] Parent MediaContainer", code, errorResponse)
                 throw RuntimeException(
                     "[Instagram][Step2] Creation of Parent MediaContainer Failed: ${errorResponse?.error?.message ?: "Unknown error"}",
                 )
             }
-            // 5~10초 사이 랜덤 추출 TODO: 이미지 컨테이너 올라갔는지 폴링하도록 변경
-            DelayUtil.randomDelay(10, 15)
 
-            return responseBody?.let { parseJsonForId(it).id }
+            // TODO: 이미지 컨테이너 올라갔는지 폴링하도록 변경
+            DelayUtil.randomDelay(10, 15)
+            responseBody?.let { parseJsonForId(it).id }
         }
-    }
 
     // 3단계: 최종 게시
-    fun publishMedia(creationId: String): Boolean {
-        val url =
-            "https://graph.instagram.com/$accountId/media_publish"
-                .toHttpUrlOrNull()
-                ?.newBuilder()
-                ?.addQueryParameter("access_token", instagramTokenService.getLatestAccessToken())
-                ?.addQueryParameter("creation_id", creationId)
-                ?.build()
+    suspend fun publishMedia(creationId: String): Boolean =
+        withContext(Dispatchers.IO) {
+            val url =
+                "https://graph.instagram.com/$accountId/media_publish"
+                    .toHttpUrlOrNull()
+                    ?.newBuilder()
+                    ?.addQueryParameter("access_token", instagramTokenService.getLatestAccessToken())
+                    ?.addQueryParameter("creation_id", creationId)
+                    ?.build()
 
-        val request =
-            Request
-                .Builder()
-                .url(url!!)
-                .post(RequestBody.create(null, ""))
-                .build()
+            val request =
+                Request
+                    .Builder()
+                    .url(url!!)
+                    .post(RequestBody.create(null, ""))
+                    .build()
 
-        instagramOkHttpClient.newCall(request).execute().use { response ->
-            val responseBody = response.body?.string()
-            if (!response.isSuccessful) {
-                val errorResponse = parseErrorResponse(responseBody)
-                logErrorResponse("[Step3] Publish Media", response.code, errorResponse)
-                throw RuntimeException(
-                    "[Instagram][Step3] Publishing Media Failed: ${errorResponse?.error?.message ?: "Unknown error"}",
-                )
+            instagramOkHttpClient.newCall(request).execute().use { response ->
+                val responseBody = response.body?.string()
+                if (!response.isSuccessful) {
+                    val errorResponse = parseErrorResponse(responseBody)
+                    logErrorResponse("[Step3] Publish Media", response.code, errorResponse)
+                    throw RuntimeException(
+                        "[Instagram][Step3] Publishing Media Failed: ${errorResponse?.error?.message ?: "Unknown error"}",
+                    )
+                }
+                response.isSuccessful
             }
-            return response.isSuccessful
         }
-    }
 
     private fun parseJsonForId(json: String): InstagramResponse = gson.fromJson(json, InstagramResponse::class.java)
 

--- a/domain/generator/src/main/kotlin/com/few/generator/core/instagram/InstagramUploader.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/instagram/InstagramUploader.kt
@@ -69,7 +69,7 @@ class InstagramUploader(
                 )
             }
             // 5~10초 사이 랜덤 추출 TODO: 이미지 컨테이너 올라갔는지 폴링하도록 변경
-            DelayUtil.randomDelay(5, 10)
+            DelayUtil.randomDelay(10, 15)
 
             return responseBody?.let { parseJsonForId(it).id }
         }
@@ -107,7 +107,7 @@ class InstagramUploader(
                 )
             }
             // 5~10초 사이 랜덤 추출 TODO: 이미지 컨테이너 올라갔는지 폴링하도록 변경
-            DelayUtil.randomDelay(5, 10)
+            DelayUtil.randomDelay(10, 15)
 
             return responseBody?.let { parseJsonForId(it).id }
         }

--- a/domain/generator/src/main/kotlin/com/few/generator/core/instagram/InstagramUploader.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/core/instagram/InstagramUploader.kt
@@ -6,13 +6,20 @@ import com.few.generator.support.utils.DelayUtil
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import okhttp3.*
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 data class InstagramResponse(
     val id: String,
@@ -42,86 +49,130 @@ class InstagramUploader(
     private val log = KotlinLogging.logger {}
 
     // 1단계: 개별 이미지용 컨테이너 생성
-    suspend fun createChildMediaContainer(imageUrl: String): String? =
-        withContext(Dispatchers.IO) {
-            val url =
-                "https://graph.instagram.com/$accountId/media"
-                    .toHttpUrlOrNull()
-                    ?.newBuilder()
-                    ?.addQueryParameter("access_token", instagramTokenService.getLatestAccessToken())
-                    ?.addQueryParameter("image_url", imageUrl)
-                    ?.addQueryParameter("is_carousel_item", "true")
-                    ?.build()
+    suspend fun createChildMediaContainer(imageUrl: String): String? {
+        val responseBody =
+            suspendCancellableCoroutine { continuation ->
+                val url =
+                    "https://graph.instagram.com/$accountId/media"
+                        .toHttpUrlOrNull()
+                        ?.newBuilder()
+                        ?.addQueryParameter("access_token", instagramTokenService.getLatestAccessToken())
+                        ?.addQueryParameter("image_url", imageUrl)
+                        ?.addQueryParameter("is_carousel_item", "true")
+                        ?.build()
 
-            val request =
-                Request
-                    .Builder()
-                    .url(url!!)
-                    .post(RequestBody.create(null, ""))
-                    .build()
+                val request =
+                    Request
+                        .Builder()
+                        .url(url!!)
+                        .post(RequestBody.create(null, ""))
+                        .build()
 
-            val (responseBody, isSuccessful, code) =
-                instagramOkHttpClient.newCall(request).execute().use { response ->
-                    Triple(response.body?.string(), response.isSuccessful, response.code)
-                }
+                val call = instagramOkHttpClient.newCall(request)
+                continuation.invokeOnCancellation { call.cancel() }
 
-            if (!isSuccessful) {
-                val errorResponse = parseErrorResponse(responseBody)
-                logErrorResponse("[Step1] Child MediaContainer", code, errorResponse)
-                throw RuntimeException(
-                    "[Instagram][Step1] Creation of Child MediaContainer Failed: ${errorResponse?.error?.message ?: "Unknown error"}",
+                call.enqueue(
+                    object : Callback {
+                        override fun onResponse(
+                            call: Call,
+                            response: Response,
+                        ) {
+                            response.use {
+                                if (!response.isSuccessful) {
+                                    val errorResponse = parseErrorResponse(response.body?.string())
+                                    logErrorResponse("[Step1] Child MediaContainer", response.code, errorResponse)
+                                    continuation.resumeWithException(
+                                        RuntimeException(
+                                            "[Instagram][Step1] Creation of Child MediaContainer Failed: ${errorResponse?.error?.message ?: "Unknown error"}",
+                                        ),
+                                    )
+                                } else {
+                                    continuation.resume(response.body?.string())
+                                }
+                            }
+                        }
+
+                        override fun onFailure(
+                            call: Call,
+                            e: IOException,
+                        ) {
+                            continuation.resumeWithException(e)
+                        }
+                    },
                 )
             }
 
-            // TODO: 이미지 컨테이너 올라갔는지 폴링하도록 변경
-            DelayUtil.randomDelay(10, 15)
-            responseBody?.let { parseJsonForId(it).id }
-        }
+        // TODO: 이미지 컨테이너 올라갔는지 폴링하도록 변경
+        DelayUtil.randomDelay(10, 15)
+        return responseBody?.let { parseJsonForId(it).id }
+    }
 
     // 2단계: 캐러셀용 부모 컨테이너 생성
     suspend fun createParentMediaContainer(
         imageUrls: List<String>,
         caption: String,
-    ): String? =
-        withContext(Dispatchers.IO) {
-            val url =
-                "https://graph.instagram.com/$accountId/media"
-                    .toHttpUrlOrNull()
-                    ?.newBuilder()
-                    ?.addQueryParameter("access_token", instagramTokenService.getLatestAccessToken())
-                    ?.addQueryParameter("children", imageUrls.joinToString(separator = ","))
-                    ?.addQueryParameter("caption", caption)
-                    ?.addQueryParameter("media_type", "CAROUSEL")
-                    ?.build()
+    ): String? {
+        val responseBody =
+            suspendCancellableCoroutine { continuation ->
+                val url =
+                    "https://graph.instagram.com/$accountId/media"
+                        .toHttpUrlOrNull()
+                        ?.newBuilder()
+                        ?.addQueryParameter("access_token", instagramTokenService.getLatestAccessToken())
+                        ?.addQueryParameter("children", imageUrls.joinToString(separator = ","))
+                        ?.addQueryParameter("caption", caption)
+                        ?.addQueryParameter("media_type", "CAROUSEL")
+                        ?.build()
 
-            val request =
-                Request
-                    .Builder()
-                    .url(url!!)
-                    .post(RequestBody.create(null, ""))
-                    .build()
+                val request =
+                    Request
+                        .Builder()
+                        .url(url!!)
+                        .post(RequestBody.create(null, ""))
+                        .build()
 
-            val (responseBody, isSuccessful, code) =
-                instagramOkHttpClient.newCall(request).execute().use { response ->
-                    Triple(response.body?.string(), response.isSuccessful, response.code)
-                }
+                val call = instagramOkHttpClient.newCall(request)
+                continuation.invokeOnCancellation { call.cancel() }
 
-            if (!isSuccessful) {
-                val errorResponse = parseErrorResponse(responseBody)
-                logErrorResponse("[Step2] Parent MediaContainer", code, errorResponse)
-                throw RuntimeException(
-                    "[Instagram][Step2] Creation of Parent MediaContainer Failed: ${errorResponse?.error?.message ?: "Unknown error"}",
+                call.enqueue(
+                    object : Callback {
+                        override fun onResponse(
+                            call: Call,
+                            response: Response,
+                        ) {
+                            response.use {
+                                if (!response.isSuccessful) {
+                                    val errorResponse = parseErrorResponse(response.body?.string())
+                                    logErrorResponse("[Step2] Parent MediaContainer", response.code, errorResponse)
+                                    continuation.resumeWithException(
+                                        RuntimeException(
+                                            "[Instagram][Step2] Creation of Parent MediaContainer Failed: ${errorResponse?.error?.message ?: "Unknown error"}",
+                                        ),
+                                    )
+                                } else {
+                                    continuation.resume(response.body?.string())
+                                }
+                            }
+                        }
+
+                        override fun onFailure(
+                            call: Call,
+                            e: IOException,
+                        ) {
+                            continuation.resumeWithException(e)
+                        }
+                    },
                 )
             }
 
-            // TODO: 이미지 컨테이너 올라갔는지 폴링하도록 변경
-            DelayUtil.randomDelay(10, 15)
-            responseBody?.let { parseJsonForId(it).id }
-        }
+        // TODO: 이미지 컨테이너 올라갔는지 폴링하도록 변경
+        DelayUtil.randomDelay(10, 15)
+        return responseBody?.let { parseJsonForId(it).id }
+    }
 
     // 3단계: 최종 게시
     suspend fun publishMedia(creationId: String): Boolean =
-        withContext(Dispatchers.IO) {
+        suspendCancellableCoroutine { continuation ->
             val url =
                 "https://graph.instagram.com/$accountId/media_publish"
                     .toHttpUrlOrNull()
@@ -137,17 +188,38 @@ class InstagramUploader(
                     .post(RequestBody.create(null, ""))
                     .build()
 
-            instagramOkHttpClient.newCall(request).execute().use { response ->
-                val responseBody = response.body?.string()
-                if (!response.isSuccessful) {
-                    val errorResponse = parseErrorResponse(responseBody)
-                    logErrorResponse("[Step3] Publish Media", response.code, errorResponse)
-                    throw RuntimeException(
-                        "[Instagram][Step3] Publishing Media Failed: ${errorResponse?.error?.message ?: "Unknown error"}",
-                    )
-                }
-                response.isSuccessful
-            }
+            val call = instagramOkHttpClient.newCall(request)
+            continuation.invokeOnCancellation { call.cancel() }
+
+            call.enqueue(
+                object : Callback {
+                    override fun onResponse(
+                        call: Call,
+                        response: Response,
+                    ) {
+                        response.use {
+                            if (!response.isSuccessful) {
+                                val errorResponse = parseErrorResponse(response.body?.string())
+                                logErrorResponse("[Step3] Publish Media", response.code, errorResponse)
+                                continuation.resumeWithException(
+                                    RuntimeException(
+                                        "[Instagram][Step3] Publishing Media Failed: ${errorResponse?.error?.message ?: "Unknown error"}",
+                                    ),
+                                )
+                            } else {
+                                continuation.resume(response.isSuccessful)
+                            }
+                        }
+                    }
+
+                    override fun onFailure(
+                        call: Call,
+                        e: IOException,
+                    ) {
+                        continuation.resumeWithException(e)
+                    }
+                },
+            )
         }
 
     private fun parseJsonForId(json: String): InstagramResponse = gson.fromJson(json, InstagramResponse::class.java)

--- a/domain/generator/src/main/kotlin/com/few/generator/event/listener/CardNewsS3UploadedEventListener.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/listener/CardNewsS3UploadedEventListener.kt
@@ -6,8 +6,6 @@ import com.few.web.client.Block
 import com.few.web.client.SlackBodyProperty
 import com.few.web.client.Text
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import java.time.format.DateTimeFormatter
@@ -15,21 +13,17 @@ import java.time.format.DateTimeFormatter
 @Component
 class CardNewsS3UploadedEventListener(
     private val slackWebhookClient: SlackWebhookClient,
-    private val notificationIoCoroutineScope: CoroutineScope,
 ) {
     private val log = KotlinLogging.logger {}
 
     @EventListener
     fun handleEvent(event: CardNewsS3UploadedEvent) {
-        notificationIoCoroutineScope.launch {
-            log.info { "${event.region.name} 카드뉴스 S3 업로드 완료 감지, Slack 알림 발송 시작" }
-
-            try {
-                sendSlackNotification(event)
-                log.info { "${event.region.name} 카드뉴스 S3 업로드 Slack 알림 발송 완료" }
-            } catch (e: Exception) {
-                log.error(e) { "${event.region.name} Slack 알림 발송 실패" }
-            }
+        log.info { "${event.region.name} 카드뉴스 S3 업로드 완료 감지, Slack 알림 발송 시작" }
+        try {
+            sendSlackNotification(event)
+            log.info { "${event.region.name} 카드뉴스 S3 업로드 Slack 알림 발송 완료" }
+        } catch (e: Exception) {
+            log.error(e) { "${event.region.name} Slack 알림 발송 실패" }
         }
     }
 

--- a/domain/generator/src/main/kotlin/com/few/generator/event/listener/ContentsSchedulingEventListener.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/listener/ContentsSchedulingEventListener.kt
@@ -3,22 +3,17 @@ package com.few.generator.event.listener
 import com.few.generator.event.ContentsSchedulingEvent
 import com.few.generator.event.handler.ContentsSchedulingHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
 @Component
 class ContentsSchedulingEventListener(
     private val contentsSchedulingHandler: ContentsSchedulingHandler,
-    private val notificationIoCoroutineScope: CoroutineScope,
 ) {
     private val log = KotlinLogging.logger {}
 
     @EventListener
     fun handleEvent(event: ContentsSchedulingEvent) {
-        notificationIoCoroutineScope.launch {
-            contentsSchedulingHandler.handle(event)
-        }
+        contentsSchedulingHandler.handle(event)
     }
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/event/listener/EnrollSubscriptionEventListener.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/listener/EnrollSubscriptionEventListener.kt
@@ -3,22 +3,17 @@ package com.few.generator.event.listener
 import com.few.generator.event.EnrollSubscriptionEvent
 import com.few.generator.event.handler.EnrollSubscriptionHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
 @Component
 class EnrollSubscriptionEventListener(
     private val enrollSubscriptionHandler: EnrollSubscriptionHandler,
-    private val notificationIoCoroutineScope: CoroutineScope,
 ) {
     private val log = KotlinLogging.logger {}
 
     @EventListener
     fun handleEvent(event: EnrollSubscriptionEvent) {
-        notificationIoCoroutineScope.launch {
-            enrollSubscriptionHandler.handle(event)
-        }
+        enrollSubscriptionHandler.handle(event)
     }
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/event/listener/InstagramUploadCompletedEventListener.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/listener/InstagramUploadCompletedEventListener.kt
@@ -6,8 +6,6 @@ import com.few.web.client.Block
 import com.few.web.client.SlackBodyProperty
 import com.few.web.client.Text
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import java.time.format.DateTimeFormatter
@@ -15,21 +13,17 @@ import java.time.format.DateTimeFormatter
 @Component
 class InstagramUploadCompletedEventListener(
     private val slackWebhookClient: SlackWebhookClient,
-    private val notificationIoCoroutineScope: CoroutineScope,
 ) {
     private val log = KotlinLogging.logger {}
 
     @EventListener
     fun handleEvent(event: InstagramUploadCompletedEvent) {
-        notificationIoCoroutineScope.launch {
-            log.info { "${event.region.name} Instagram 업로드 완료 감지, Slack 알림 발송 시작" }
-
-            try {
-                sendSlackNotification(event)
-                log.info { "${event.region.name} Instagram 업로드 Slack 알림 발송 완료" }
-            } catch (e: Exception) {
-                log.error(e) { "${event.region.name} Instagram 업로드 Slack 알림 발송 실패" }
-            }
+        log.info { "${event.region.name} Instagram 업로드 완료 감지, Slack 알림 발송 시작" }
+        try {
+            sendSlackNotification(event)
+            log.info { "${event.region.name} Instagram 업로드 Slack 알림 발송 완료" }
+        } catch (e: Exception) {
+            log.error(e) { "${event.region.name} Instagram 업로드 Slack 알림 발송 실패" }
         }
     }
 

--- a/domain/generator/src/main/kotlin/com/few/generator/event/listener/StockBriefingInstagramUploadFailedEventListener.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/listener/StockBriefingInstagramUploadFailedEventListener.kt
@@ -6,8 +6,6 @@ import com.few.web.client.Block
 import com.few.web.client.SlackBodyProperty
 import com.few.web.client.Text
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import java.time.format.DateTimeFormatter
@@ -15,7 +13,6 @@ import java.time.format.DateTimeFormatter
 @Component
 class StockBriefingInstagramUploadFailedEventListener(
     private val slackWebhookClient: SlackWebhookClient,
-    private val notificationIoCoroutineScope: CoroutineScope,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -23,15 +20,12 @@ class StockBriefingInstagramUploadFailedEventListener(
     fun handleEvent(event: StockBriefingInstagramUploadCompletedEvent) {
         if (event.success) return
 
-        notificationIoCoroutineScope.launch {
-            log.info { "증시 브리핑 실패 감지 (postId=${event.postId}, 단계=${event.failedStage}), Slack 알림 발송 시작" }
-
-            try {
-                sendFailureSlackNotification(event)
-                log.info { "증시 브리핑 실패 Slack 알림 발송 완료 (postId=${event.postId})" }
-            } catch (e: Exception) {
-                log.error(e) { "증시 브리핑 실패 Slack 알림 발송 실패" }
-            }
+        log.info { "증시 브리핑 실패 감지 (postId=${event.postId}, 단계=${event.failedStage}), Slack 알림 발송 시작" }
+        try {
+            sendFailureSlackNotification(event)
+            log.info { "증시 브리핑 실패 Slack 알림 발송 완료 (postId=${event.postId})" }
+        } catch (e: Exception) {
+            log.error(e) { "증시 브리핑 실패 Slack 알림 발송 실패" }
         }
     }
 

--- a/domain/generator/src/main/kotlin/com/few/generator/event/listener/UnsubscribeEventListener.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/listener/UnsubscribeEventListener.kt
@@ -3,22 +3,17 @@ package com.few.generator.event.listener
 import com.few.generator.event.UnsubscribeEvent
 import com.few.generator.event.handler.UnsubscribeHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
 @Component
 class UnsubscribeEventListener(
     private val unsubscribeHandler: UnsubscribeHandler,
-    private val notificationIoCoroutineScope: CoroutineScope,
 ) {
     private val log = KotlinLogging.logger {}
 
     @EventListener
     fun handleEvent(event: UnsubscribeEvent) {
-        notificationIoCoroutineScope.launch {
-            unsubscribeHandler.handle(event)
-        }
+        unsubscribeHandler.handle(event)
     }
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/support/utils/DelayUtil.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/support/utils/DelayUtil.kt
@@ -1,31 +1,22 @@
 package com.few.generator.support.utils
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.delay
 
 object DelayUtil {
     private val log = KotlinLogging.logger {}
 
-    /**
-     * fromSec와 toSec 사이의 시간을 랜덤하게 선택하여 현재 스레드를 정지시킵니다.
-     */
-    fun randomDelay(
+    suspend fun randomDelay(
         fromSec: Int,
         toSec: Int,
     ) {
         require(fromSec >= 0 && toSec >= 0) { "fromSec/toSec는 0 이상이어야 합니다." }
         require(fromSec <= toSec) { "fromSec는 toSec 이하여야 합니다." }
 
-        // 1. from과 to 사이의 랜덤한 밀리초(ms) 계산
         val range = (fromSec.toLong() * 1000)..(toSec.toLong() * 1000)
         val delayMillis = range.random()
 
-        try {
-            // 2. 해당 시간만큼 스레드 정지
-            log.info { "Thread will be Delayed... ${delayMillis}ms 후 다음 작업 진행" }
-            Thread.sleep(delayMillis)
-        } catch (e: InterruptedException) {
-            // 3. 인터럽트 발생 시 현재 스레드의 상태 재설정
-            Thread.currentThread().interrupt()
-        }
+        log.info { "Coroutine suspended for ${delayMillis}ms" }
+        delay(delayMillis)
     }
 }

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/AbstractGroupGenSchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/AbstractGroupGenSchedulingUseCase.kt
@@ -19,8 +19,6 @@ import com.few.generator.support.jpa.GeneratorTransactional
 import com.google.gson.Gson
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.runBlocking
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.ApplicationEventPublisher
@@ -39,10 +37,11 @@ abstract class AbstractGroupGenSchedulingUseCase(
     protected val keywordExtractor: KeywordExtractor,
     protected val genGrouper: GenGroupper,
     protected val groupContentGenerator: GroupContentGenerator,
+    @Qualifier("groupGenCoroutineScope")
+    private val groupGenScope: CoroutineScope,
 ) {
     protected val log = KotlinLogging.logger {}
     protected val isRunning = AtomicBoolean(false)
-    protected val groupGenScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     abstract val region: Region
     abstract val regionName: String

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/GlobalGroupGenSchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/GlobalGroupGenSchedulingUseCase.kt
@@ -11,6 +11,7 @@ import com.few.generator.service.specifics.groupgen.GroupContentGenerator
 import com.few.generator.service.specifics.groupgen.GroupGenMetrics
 import com.few.generator.service.specifics.groupgen.KeywordExtractor
 import com.google.gson.Gson
+import kotlinx.coroutines.CoroutineScope
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
@@ -29,6 +30,8 @@ class GlobalGroupGenSchedulingUseCase(
     keywordExtractor: KeywordExtractor,
     genGrouper: GenGroupper,
     groupContentGenerator: GroupContentGenerator,
+    @Qualifier("groupGenCoroutineScope")
+    groupGenCoroutineScope: CoroutineScope,
 ) : AbstractGroupGenSchedulingUseCase(
         applicationEventPublisher,
         genService,
@@ -39,6 +42,7 @@ class GlobalGroupGenSchedulingUseCase(
         keywordExtractor,
         genGrouper,
         groupContentGenerator,
+        groupGenCoroutineScope,
     ) {
     override val region = Region.GLOBAL
     override val regionName = "GLOBAL"

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/LocalGroupGenSchedulingUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/LocalGroupGenSchedulingUseCase.kt
@@ -11,6 +11,7 @@ import com.few.generator.service.specifics.groupgen.GroupContentGenerator
 import com.few.generator.service.specifics.groupgen.GroupGenMetrics
 import com.few.generator.service.specifics.groupgen.KeywordExtractor
 import com.google.gson.Gson
+import kotlinx.coroutines.CoroutineScope
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
@@ -29,6 +30,8 @@ class LocalGroupGenSchedulingUseCase(
     keywordExtractor: KeywordExtractor,
     genGrouper: GenGroupper,
     groupContentGenerator: GroupContentGenerator,
+    @Qualifier("groupGenCoroutineScope")
+    groupGenCoroutineScope: CoroutineScope,
 ) : AbstractGroupGenSchedulingUseCase(
         applicationEventPublisher,
         genService,
@@ -39,6 +42,7 @@ class LocalGroupGenSchedulingUseCase(
         keywordExtractor,
         genGrouper,
         groupContentGenerator,
+        groupGenCoroutineScope,
     ) {
     override val region = Region.LOCAL
     override val regionName = "LOCAL"

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/UploadCardNewsInstagramUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/UploadCardNewsInstagramUseCase.kt
@@ -11,10 +11,12 @@ import com.few.generator.event.InstagramUploadCompletedEvent
 import com.few.generator.service.GenService
 import com.few.generator.support.utils.DelayUtil
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -31,6 +33,8 @@ class UploadCardNewsInstagramUseCase(
     protected val contentsCountByCategory: Int,
     @Value("\${generator.instagram.card-news-upload-enabled}")
     protected val cardNewsInstagramUploadEnabled: Boolean,
+    @Qualifier("instagramCoroutineScope")
+    private val scope: CoroutineScope,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -49,7 +53,6 @@ class UploadCardNewsInstagramUseCase(
             )
     }
 
-    @Async("generatorSchedulingExecutor")
     @EventListener
     fun onCardNewsS3Uploaded(event: CardNewsS3UploadedEvent) {
         if (!cardNewsInstagramUploadEnabled) {
@@ -62,7 +65,10 @@ class UploadCardNewsInstagramUseCase(
         }
 
         log.info { "${event.region.name} S3 업로드 완료 감지, Instagram 업로드 시작 (${event.uploadedUrlsByCategory.size}개 카테고리)" }
+        scope.launch { performUpload(event) }
+    }
 
+    private suspend fun performUpload(event: CardNewsS3UploadedEvent) {
         val successCategories = mutableListOf<Category>()
         val failedCategories = mutableListOf<Category>()
         val errorMessages = mutableMapOf<Category, String>()
@@ -159,7 +165,7 @@ class UploadCardNewsInstagramUseCase(
         }
     }
 
-    private fun uploadCarouselByCategory(
+    private suspend fun uploadCarouselByCategory(
         category: Category,
         imageUrls: List<String>,
         caption: String,

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/UploadStockBriefingInstagramUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/UploadStockBriefingInstagramUseCase.kt
@@ -8,9 +8,11 @@ import com.few.generator.event.StockBriefingInstagramUploadCompletedEvent
 import com.few.generator.event.StockBriefingS3UploadedEvent
 import com.few.generator.support.utils.DelayUtil
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -22,6 +24,8 @@ class UploadStockBriefingInstagramUseCase(
     private val chatGpt: ChatGpt,
     private val promptGenerator: PromptGenerator,
     private val applicationEventPublisher: ApplicationEventPublisher,
+    @Qualifier("instagramCoroutineScope")
+    private val scope: CoroutineScope,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -31,7 +35,6 @@ class UploadStockBriefingInstagramUseCase(
         private val FALLBACK_HASHTAGS = listOf("증시브리핑", "주식", "코스피", "나스닥", "주식투자")
     }
 
-    @Async("generatorSchedulingExecutor")
     @EventListener
     fun onStockBriefingS3Uploaded(event: StockBriefingS3UploadedEvent) {
         if (event.detailImageUrls.isEmpty()) {
@@ -41,7 +44,10 @@ class UploadStockBriefingInstagramUseCase(
         }
 
         log.info { "증시 브리핑 S3 업로드 완료 감지 (postId=${event.postId}), Instagram 업로드 시작" }
+        scope.launch { performUpload(event) }
+    }
 
+    private suspend fun performUpload(event: StockBriefingS3UploadedEvent) {
         try {
             val allImageUrls =
                 if (event.mainPageImageUrl != null) {

--- a/domain/generator/src/test/kotlin/com/few/generator/usecase/AbstractGroupGenSchedulingUseCaseTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/usecase/AbstractGroupGenSchedulingUseCaseTest.kt
@@ -21,6 +21,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.*
+import kotlinx.coroutines.test.TestScope
 import org.springframework.context.ApplicationEventPublisher
 import java.time.LocalDateTime
 
@@ -63,6 +64,7 @@ class AbstractGroupGenSchedulingUseCaseTest :
                 keywordExtractor,
                 genGrouper,
                 groupContentGenerator,
+                TestScope(),
             ) {
             override val region: Region = Region.GLOBAL
             override val regionName: String = "해외"

--- a/domain/generator/src/test/kotlin/com/few/generator/usecase/AbstractGroupGenSchedulingUseCaseTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/usecase/AbstractGroupGenSchedulingUseCaseTest.kt
@@ -21,7 +21,9 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.springframework.context.ApplicationEventPublisher
 import java.time.LocalDateTime
 
@@ -44,6 +46,7 @@ class AbstractGroupGenSchedulingUseCaseTest :
         val groupContentGenerator = mockk<GroupContentGenerator>()
 
         // Test implementation of abstract class
+        @OptIn(ExperimentalCoroutinesApi::class)
         class TestGroupGenSchedulingUseCase(
             applicationEventPublisher: ApplicationEventPublisher,
             genService: GenService,
@@ -64,16 +67,11 @@ class AbstractGroupGenSchedulingUseCaseTest :
                 keywordExtractor,
                 genGrouper,
                 groupContentGenerator,
-                TestScope(),
+                TestScope(UnconfinedTestDispatcher()),
             ) {
             override val region: Region = Region.GLOBAL
             override val regionName: String = "해외"
             override val eventTitle: String = "[해외] Group Gen 스케줄링"
-
-            // Expose execute for testing
-            public override fun execute() {
-                super.execute()
-            }
 
             // Expose isRunning for testing
             fun getIsRunning() = isRunning.get()

--- a/domain/generator/src/test/kotlin/com/few/generator/usecase/UploadCardNewsInstagramUseCaseTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/usecase/UploadCardNewsInstagramUseCaseTest.kt
@@ -15,10 +15,11 @@ import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.string.shouldStartWith
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
 import org.springframework.context.ApplicationEventPublisher
 import java.time.LocalDateTime
 
-class InstagramUploadUseCaseTest :
+class UploadCardNewsInstagramUseCaseTest :
     BehaviorSpec({
         val instagramUploader = mockk<InstagramUploader>()
         val genService = mockk<GenService>()
@@ -35,6 +36,7 @@ class InstagramUploadUseCaseTest :
                 promptGenerator = promptGenerator,
                 contentsCountByCategory = 5,
                 cardNewsInstagramUploadEnabled = true,
+                scope = TestScope(),
             )
 
         val uploadTime = LocalDateTime.of(2025, 1, 15, 10, 0)

--- a/domain/generator/src/test/kotlin/com/few/generator/usecase/UploadStockBriefingInstagramUseCaseTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/usecase/UploadStockBriefingInstagramUseCaseTest.kt
@@ -10,6 +10,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.mockk.*
+import kotlinx.coroutines.test.TestScope
 import org.springframework.context.ApplicationEventPublisher
 import java.time.LocalDateTime
 
@@ -26,6 +27,7 @@ class UploadStockBriefingInstagramUseCaseTest :
                 chatGpt = chatGpt,
                 promptGenerator = promptGenerator,
                 applicationEventPublisher = publisher,
+                scope = TestScope(),
             )
 
         val uploadTime = LocalDateTime.of(2025, 5, 30, 13, 10)


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #967 , #964 

💁‍♂️ PR 내용
----

🙈 PR 참고 사항
----

🚩 추가된 SQL 운영계 실행계획
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 이미지 생성 대기 시간을 5–10초에서 10–15초로 늘려 업로드 안정성을 향상했습니다.

* **리팩토링**
  * 업로드 및 스케줄링 실행을 분리된 코루틴 범위로 재구성하고 업로드 흐름을 코루틴 기반으로 전환했습니다.
  * 여러 이벤트 리스너의 비동기 래핑을 동기 호출로 정리해 실행 흐름을 단순화했습니다.

* **기타**
  * 대기 유틸을 블로킹에서 논블로킹(코루틴) 방식으로 전환해 리소스 사용을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->