### PR TITLE
[Feat/#998] 나스닥 인기 종목 카드뉴스 인스타그램 업로드 UseCase 구현

### DIFF
--- a/domain/generator/src/main/kotlin/com/few/generator/event/PopularNasdaqCardNewsImageGeneratedEvent.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/PopularNasdaqCardNewsImageGeneratedEvent.kt
@@ -3,4 +3,5 @@ package com.few.generator.event
 data class PopularNasdaqCardNewsImageGeneratedEvent(
     val imagePathsByStock: Map<String, List<String>>,
     val mainPageImagePathsByStock: Map<String, String>,
+    val headlinesByStock: Map<String, List<String>>,
 )

--- a/domain/generator/src/main/kotlin/com/few/generator/event/PopularNasdaqCardNewsS3UploadedEvent.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/event/PopularNasdaqCardNewsS3UploadedEvent.kt
@@ -1,0 +1,10 @@
+package com.few.generator.event
+
+import java.time.LocalDateTime
+
+data class PopularNasdaqCardNewsS3UploadedEvent(
+    val uploadTime: LocalDateTime,
+    val detailImageUrlsByStock: Map<String, List<String>>,
+    val mainPageImageUrlsByStock: Map<String, String>,
+    val headlinesByStock: Map<String, List<String>>,
+)

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsImageGenerateUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsImageGenerateUseCase.kt
@@ -43,6 +43,7 @@ class PopularNasdaqCardNewsImageGenerateUseCase(
         val dateStr = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
         val imagePathsByStock = mutableMapOf<String, List<String>>()
         val mainPageImagePathsByStock = mutableMapOf<String, String>()
+        val headlinesByStock = mutableMapOf<String, List<String>>()
 
         genIdsByStock.forEach { (stockName, genIds) ->
             val gens = genService.findByIdInOrderByIdAsc(genIds)
@@ -97,6 +98,7 @@ class PopularNasdaqCardNewsImageGenerateUseCase(
             log.info { "[$stockName] 메인 카드 이미지 생성 완료: $mainPath" }
             imagePathsByStock[stockName] = detailPaths
             mainPageImagePathsByStock[stockName] = mainPath
+            headlinesByStock[stockName] = newsContents.map { it.headline }
         }
 
         if (imagePathsByStock.isNotEmpty()) {
@@ -104,6 +106,7 @@ class PopularNasdaqCardNewsImageGenerateUseCase(
                 PopularNasdaqCardNewsImageGeneratedEvent(
                     imagePathsByStock = imagePathsByStock,
                     mainPageImagePathsByStock = mainPageImagePathsByStock,
+                    headlinesByStock = headlinesByStock,
                 ),
             )
             log.info { "Popular Nasdaq 카드뉴스 이미지 생성 완료 이벤트 발행: ${imagePathsByStock.size}개 종목" }

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
@@ -24,8 +24,8 @@ class PopularNasdaqCardNewsInstagramUploadUseCase(
     private val promptGenerator: PromptGenerator,
     @Value("\${generator.instagram.card-news-upload-enabled}")
     private val cardNewsUploadEnabled: Boolean,
-    @Value("\${generator.instagram.popular-nasdaq-max-images}")
-    private val popularNasdaqMaxImages: Int,
+    @Value("\${generator.instagram.carousel-max-images}")
+    private val carouselMaxImages: Int,
     @Qualifier("instagramCoroutineScope")
     private val scope: CoroutineScope,
 ) {
@@ -58,7 +58,7 @@ class PopularNasdaqCardNewsInstagramUploadUseCase(
                 val mainPageUrl = event.mainPageImageUrlsByStock[stockName]
                 val allImageUrls =
                     (if (mainPageUrl != null) listOf(mainPageUrl) + detailUrls else detailUrls)
-                        .take(popularNasdaqMaxImages)
+                        .take(carouselMaxImages)
                 val headlines = event.headlinesByStock[stockName] ?: throw IllegalStateException("[$stockName] 헤드라인 정보 없음")
 
                 val caption = generateCaption(stockName, event.uploadTime, headlines)

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
@@ -1,0 +1,152 @@
+package com.few.generator.usecase
+
+import com.few.generator.core.gpt.ChatGpt
+import com.few.generator.core.gpt.prompt.PromptGenerator
+import com.few.generator.core.gpt.prompt.schema.Keywords
+import com.few.generator.core.instagram.InstagramUploader
+import com.few.generator.event.PopularNasdaqCardNewsS3UploadedEvent
+import com.few.generator.support.utils.DelayUtil
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@Component
+class PopularNasdaqCardNewsInstagramUploadUseCase(
+    private val instagramUploader: InstagramUploader,
+    private val chatGpt: ChatGpt,
+    private val promptGenerator: PromptGenerator,
+    @Value("\${generator.instagram.card-news-upload-enabled}")
+    private val cardNewsUploadEnabled: Boolean,
+    @Qualifier("instagramCoroutineScope")
+    private val scope: CoroutineScope,
+) {
+    private val log = KotlinLogging.logger {}
+
+    companion object {
+        private const val MAX_HASHTAGS = 5
+        private val DATE_FORMATTER = DateTimeFormatter.ofPattern("M월 d일", Locale.KOREAN)
+        private val FALLBACK_HASHTAGS = listOf("나스닥", "미국주식", "주식", "주식투자", "NASDAQ")
+    }
+
+    @EventListener
+    fun onPopularNasdaqCardNewsS3Uploaded(event: PopularNasdaqCardNewsS3UploadedEvent) {
+        if (!cardNewsUploadEnabled) {
+            log.info { "Popular Nasdaq 인스타그램 업로드가 비활성화되어 Skip 합니다." }
+            return
+        }
+        if (event.detailImageUrlsByStock.isEmpty()) {
+            log.warn { "Popular Nasdaq S3 업로드된 이미지가 없어 Instagram 업로드를 건너뜁니다." }
+            return
+        }
+
+        log.info { "Popular Nasdaq S3 업로드 완료 감지, Instagram 업로드 시작 (${event.detailImageUrlsByStock.size}개 종목)" }
+        scope.launch { performUpload(event) }
+    }
+
+    private suspend fun performUpload(event: PopularNasdaqCardNewsS3UploadedEvent) {
+        event.detailImageUrlsByStock.forEach { (stockName, detailUrls) ->
+            try {
+                val mainPageUrl = event.mainPageImageUrlsByStock[stockName]
+                val allImageUrls =
+                    if (mainPageUrl != null) listOf(mainPageUrl) + detailUrls else detailUrls
+                val headlines = event.headlinesByStock[stockName] ?: emptyList()
+
+                val caption = generateCaption(stockName, event.uploadTime, headlines)
+                uploadCarousel(stockName, allImageUrls, caption)
+            } catch (e: Exception) {
+                log.error(e) { "[$stockName] Instagram 업로드 처리 중 예외 발생: ${e.message}" }
+            }
+        }
+    }
+
+    fun generateCaption(
+        stockName: String,
+        uploadTime: LocalDateTime,
+        headlines: List<String>,
+    ): String {
+        val hashtags = generateDynamicHashtags(headlines)
+        val allHashtags = hashtags.joinToString(" ") { "#$it" }
+
+        return buildString {
+            appendLine("📈 few letter가 정리한 ${uploadTime.format(DATE_FORMATTER)} $stockName 주요소식")
+            appendLine()
+            headlines.forEach { appendLine(it) }
+            if (allHashtags.isNotEmpty()) {
+                appendLine()
+                append(allHashtags)
+            }
+        }
+    }
+
+    fun generateDynamicHashtags(headlines: List<String>): List<String> {
+        if (headlines.isEmpty()) return FALLBACK_HASHTAGS
+
+        return try {
+            val prompt = promptGenerator.toInstagramHashtags(headlines, MAX_HASHTAGS)
+            val keywords = chatGpt.ask(prompt) as? Keywords ?: return FALLBACK_HASHTAGS
+            keywords.keywords.map { it.replace(" ", "") }.take(MAX_HASHTAGS)
+        } catch (e: Exception) {
+            log.warn(e) { "Popular Nasdaq 동적 해시태그 생성 실패, 기본 해시태그 사용" }
+            FALLBACK_HASHTAGS
+        }
+    }
+
+    private suspend fun uploadCarousel(
+        stockName: String,
+        imageUrls: List<String>,
+        caption: String,
+    ) {
+        log.info { "[$stockName] Instagram carousel 업로드 시작: ${imageUrls.size}개 이미지" }
+
+        try {
+            val childCreationIds = mutableListOf<String>()
+            imageUrls.forEachIndexed { index, imageUrl ->
+                val childId = instagramUploader.createChildMediaContainer(imageUrl)
+                if (childId != null) {
+                    childCreationIds.add(childId)
+                    log.info { "[$stockName] Child 컨테이너 생성 성공 [${index + 1}/${imageUrls.size}]: $childId" }
+                } else {
+                    log.error { "[$stockName] Child 컨테이너 생성 실패 [${index + 1}/${imageUrls.size}]: $imageUrl" }
+                }
+            }
+
+            if (childCreationIds.isEmpty()) {
+                log.error { "[$stockName] 생성된 Child 컨테이너가 없어 carousel 업로드를 건너뜁니다." }
+                return
+            }
+
+            val parentCreationId = instagramUploader.createParentMediaContainer(childCreationIds, caption)
+            if (parentCreationId == null) {
+                log.error { "[$stockName] Parent 컨테이너 생성 실패" }
+                return
+            }
+            log.info { "[$stockName] Parent 컨테이너 생성 성공: $parentCreationId" }
+
+            DelayUtil.randomDelay(600, 1801)
+
+            val publishSuccess = instagramUploader.publishMedia(parentCreationId)
+            if (publishSuccess) {
+                log.info { "[$stockName] Instagram carousel 게시 성공: ${imageUrls.size}개 이미지" }
+            } else {
+                log.error { "[$stockName] Instagram carousel 게시 실패: parentCreationId=$parentCreationId" }
+            }
+        } catch (e: Exception) {
+            log.error(e) { "[$stockName] Instagram carousel 업로드 중 오류 발생: ${e.message}" }
+
+            val errorMsg = e.message ?: ""
+            if (errorMsg.contains("Application request limit reached")) {
+                log.info { "[$stockName] API 제한 도달, 약 1시간 대기" }
+                DelayUtil.randomDelay(3600, 4000)
+            } else {
+                DelayUtil.randomDelay(600, 700)
+            }
+        }
+    }
+}

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
@@ -55,7 +55,8 @@ class PopularNasdaqCardNewsInstagramUploadUseCase(
             try {
                 val mainPageUrl = event.mainPageImageUrlsByStock[stockName]
                 val allImageUrls =
-                    if (mainPageUrl != null) listOf(mainPageUrl) + detailUrls else detailUrls
+                    (if (mainPageUrl != null) listOf(mainPageUrl) + detailUrls else detailUrls)
+                        .let { if (it.size >= 9) it.take(9) else it }
                 val headlines = event.headlinesByStock[stockName] ?: throw IllegalStateException("[$stockName] 헤드라인 정보 없음")
 
                 val caption = generateCaption(stockName, event.uploadTime, headlines)

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
@@ -24,6 +24,8 @@ class PopularNasdaqCardNewsInstagramUploadUseCase(
     private val promptGenerator: PromptGenerator,
     @Value("\${generator.instagram.card-news-upload-enabled}")
     private val cardNewsUploadEnabled: Boolean,
+    @Value("\${generator.instagram.popular-nasdaq-max-images}")
+    private val popularNasdaqMaxImages: Int,
     @Qualifier("instagramCoroutineScope")
     private val scope: CoroutineScope,
 ) {
@@ -56,7 +58,7 @@ class PopularNasdaqCardNewsInstagramUploadUseCase(
                 val mainPageUrl = event.mainPageImageUrlsByStock[stockName]
                 val allImageUrls =
                     (if (mainPageUrl != null) listOf(mainPageUrl) + detailUrls else detailUrls)
-                        .take(9)
+                        .take(popularNasdaqMaxImages)
                 val headlines = event.headlinesByStock[stockName] ?: throw IllegalStateException("[$stockName] 헤드라인 정보 없음")
 
                 val caption = generateCaption(stockName, event.uploadTime, headlines)

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
@@ -56,7 +56,7 @@ class PopularNasdaqCardNewsInstagramUploadUseCase(
                 val mainPageUrl = event.mainPageImageUrlsByStock[stockName]
                 val allImageUrls =
                     (if (mainPageUrl != null) listOf(mainPageUrl) + detailUrls else detailUrls)
-                        .let { if (it.size >= 9) it.take(9) else it }
+                        .take(9)
                 val headlines = event.headlinesByStock[stockName] ?: throw IllegalStateException("[$stockName] 헤드라인 정보 없음")
 
                 val caption = generateCaption(stockName, event.uploadTime, headlines)

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsInstagramUploadUseCase.kt
@@ -56,7 +56,7 @@ class PopularNasdaqCardNewsInstagramUploadUseCase(
                 val mainPageUrl = event.mainPageImageUrlsByStock[stockName]
                 val allImageUrls =
                     if (mainPageUrl != null) listOf(mainPageUrl) + detailUrls else detailUrls
-                val headlines = event.headlinesByStock[stockName] ?: emptyList()
+                val headlines = event.headlinesByStock[stockName] ?: throw IllegalStateException("[$stockName] 헤드라인 정보 없음")
 
                 val caption = generateCaption(stockName, event.uploadTime, headlines)
                 uploadCarousel(stockName, allImageUrls, caption)

--- a/domain/generator/src/main/kotlin/com/few/generator/usecase/UploadPopularNasdaqCardNewsS3UseCase.kt
+++ b/domain/generator/src/main/kotlin/com/few/generator/usecase/UploadPopularNasdaqCardNewsS3UseCase.kt
@@ -1,16 +1,20 @@
 package com.few.generator.usecase
 
 import com.few.generator.event.PopularNasdaqCardNewsImageGeneratedEvent
+import com.few.generator.event.PopularNasdaqCardNewsS3UploadedEvent
 import com.few.generator.support.aws.S3Provider
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import java.io.File
+import java.time.LocalDateTime
 
 @Component
 class UploadPopularNasdaqCardNewsS3UseCase(
     private val s3Provider: S3Provider,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -22,12 +26,39 @@ class UploadPopularNasdaqCardNewsS3UseCase(
         val allDetailPaths = event.imagePathsByStock.values.flatten()
         val allMainPaths = event.mainPageImagePathsByStock.values.toList()
         val allPaths = allDetailPaths + allMainPaths
+        val uploadTime = LocalDateTime.now()
 
         try {
             val result = s3Provider.uploadImages(allPaths)
             log.info { "Popular Nasdaq 카드뉴스 S3 업로드 완료: ${result.uploadedCount}/${result.totalCount}개 성공" }
             if (result.failedCount > 0) {
                 log.warn { "Popular Nasdaq S3 업로드 실패:\n${result.getErrorMessage()}" }
+            }
+
+            val pathToUrl = result.successfulUploads.associate { it.path to it.url }
+
+            val detailImageUrlsByStock =
+                event.imagePathsByStock
+                    .mapValues { (_, paths) ->
+                        paths.mapNotNull { pathToUrl[it] }
+                    }.filter { it.value.isNotEmpty() }
+
+            val mainPageImageUrlsByStock =
+                event.mainPageImagePathsByStock
+                    .mapNotNull { (stock, path) ->
+                        pathToUrl[path]?.let { stock to it }
+                    }.toMap()
+
+            if (detailImageUrlsByStock.isNotEmpty()) {
+                applicationEventPublisher.publishEvent(
+                    PopularNasdaqCardNewsS3UploadedEvent(
+                        uploadTime = uploadTime,
+                        detailImageUrlsByStock = detailImageUrlsByStock,
+                        mainPageImageUrlsByStock = mainPageImageUrlsByStock,
+                        headlinesByStock = event.headlinesByStock,
+                    ),
+                )
+                log.info { "Popular Nasdaq S3 업로드 완료 이벤트 발행: ${detailImageUrlsByStock.size}개 종목" }
             }
         } catch (e: Exception) {
             log.error(e) { "Popular Nasdaq 카드뉴스 S3 업로드 중 예외 발생: ${e.message}" }

--- a/domain/generator/src/main/resources/application-generator-local.yaml
+++ b/domain/generator/src/main/resources/application-generator-local.yaml
@@ -76,7 +76,7 @@ generator:
     instagram:
         account-id: ${INSTAGRAM_ACCOUNT_ID}
         card-news-upload-enabled: false
-        popular-nasdaq-max-images: 9
+        carousel-max-images: 9
 
 app:
     http:

--- a/domain/generator/src/main/resources/application-generator-local.yaml
+++ b/domain/generator/src/main/resources/application-generator-local.yaml
@@ -76,6 +76,7 @@ generator:
     instagram:
         account-id: ${INSTAGRAM_ACCOUNT_ID}
         card-news-upload-enabled: false
+        popular-nasdaq-max-images: 9
 
 app:
     http:

--- a/domain/generator/src/main/resources/application-generator-prd.yaml
+++ b/domain/generator/src/main/resources/application-generator-prd.yaml
@@ -74,7 +74,7 @@ generator:
     instagram:
         account-id: ${INSTAGRAM_ACCOUNT_ID}
         card-news-upload-enabled: true
-        popular-nasdaq-max-images: 9
+        carousel-max-images: 9
 
 app:
     http:

--- a/domain/generator/src/main/resources/application-generator-prd.yaml
+++ b/domain/generator/src/main/resources/application-generator-prd.yaml
@@ -74,6 +74,7 @@ generator:
     instagram:
         account-id: ${INSTAGRAM_ACCOUNT_ID}
         card-news-upload-enabled: true
+        popular-nasdaq-max-images: 9
 
 app:
     http:

--- a/domain/generator/src/test/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsImageGenerateUseCaseTest.kt
+++ b/domain/generator/src/test/kotlin/com/few/generator/usecase/PopularNasdaqCardNewsImageGenerateUseCaseTest.kt
@@ -101,6 +101,9 @@ class PopularNasdaqCardNewsImageGenerateUseCaseTest :
             File(mainPath).exists() shouldBe true
             println("=== Apple 메인 카드 이미지 ===")
             println("  - $mainPath")
+
+            eventSlot.captured.headlinesByStock shouldContainKey "Apple"
+            eventSlot.captured.headlinesByStock["Apple"]!!.size shouldBe 4
         }
 
         test("NVDA 종목 카드뉴스 이미지 실제 생성") {
@@ -143,6 +146,9 @@ class PopularNasdaqCardNewsImageGenerateUseCaseTest :
             File(mainPath).exists() shouldBe true
             println("=== NVDA 메인 카드 이미지 ===")
             println("  - $mainPath")
+
+            eventSlot.captured.headlinesByStock shouldContainKey "NVDA"
+            eventSlot.captured.headlinesByStock["NVDA"]!!.size shouldBe 3
         }
 
         test("Microsoft 종목 카드뉴스 이미지 실제 생성") {
@@ -180,6 +186,9 @@ class PopularNasdaqCardNewsImageGenerateUseCaseTest :
             File(mainPath).exists() shouldBe true
             println("=== Microsoft 메인 카드 이미지 ===")
             println("  - $mainPath")
+
+            eventSlot.captured.headlinesByStock shouldContainKey "Microsoft"
+            eventSlot.captured.headlinesByStock["Microsoft"]!!.size shouldBe 2
         }
 
         test("여러 종목 동시 카드뉴스 이미지 실제 생성") {
@@ -209,6 +218,8 @@ class PopularNasdaqCardNewsImageGenerateUseCaseTest :
             eventSlot.captured.imagePathsByStock shouldHaveSize 2
             eventSlot.captured.imagePathsByStock shouldContainKey "Apple"
             eventSlot.captured.imagePathsByStock shouldContainKey "Tesla"
+            eventSlot.captured.headlinesByStock shouldContainKey "Apple"
+            eventSlot.captured.headlinesByStock shouldContainKey "Tesla"
 
             println("=== 여러 종목 상세 카드 이미지 ===")
             eventSlot.captured.imagePathsByStock.forEach { (stock, paths) ->


### PR DESCRIPTION
- PopularNasdaqCardNewsInstagramUploadUseCase 추가
  - PopularNasdaqCardNewsS3UploadedEvent 수신 후 종목별 carousel 포스팅 업로드
  - 메인 페이지 1장 + 상세 페이지 N장을 하나의 carousel 포스팅으로 구성
  - GPT 기반 동적 해시태그 생성 (최대 5개, 실패 시 fallback 해시태그 사용)
  - 캡션 형식: 날짜 + 종목명 + 헤드라인 목록 + 해시태그
  - card-news-upload-enabled 설정값으로 업로드 on/off 제어

- PopularNasdaqCardNewsS3UploadedEvent 추가
  - S3 업로드 완료 후 URL 맵과 헤드라인 정보를 포함해 발행

- UploadPopularNasdaqCardNewsS3UseCase 수정
  - S3 업로드 후 PopularNasdaqCardNewsS3UploadedEvent 발행하도록 변경
  - path→url 매핑을 통해 종목별 상세/메인 이미지 URL 분리 전달

- PopularNasdaqCardNewsImageGeneratedEvent에 headlinesByStock 필드 추가
  - 이미지 생성 단계에서 headline 수집 후 이벤트 체인으로 전달 (DB 재조회 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🎫 연관 이슈
---
resolved #998

💁‍♂️ PR 내용
----

🙈 PR 참고 사항
----

🚩 추가된 SQL 운영계 실행계획
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 나스닥 카드 뉴스 처리 흐름에 종목별 헤드라인 정보가 함께 전달되도록 개선되었습니다.
  * 업로드 완료 후 인스타그램 카루셀 게시가 자동으로 이어지는 기능이 추가되었습니다.
  * 게시 시 업로드 시간과 헤드라인을 반영한 캡션, 해시태그가 생성됩니다.

* **Bug Fixes**
  * 이미지나 헤드라인이 부족한 경우 업로드를 건너뛰어 실패 가능성을 줄였습니다.
  * 게시 제한이나 오류 발생 시 대기 및 대체 해시태그 처리로 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->